### PR TITLE
Add constrains to plugin::CallMathod (And bad calls)

### DIFF
--- a/source/PluginBase.h
+++ b/source/PluginBase.h
@@ -47,23 +47,27 @@ template <unsigned int address, typename... Args> void Call(Args... args) {
     reinterpret_cast<void(__cdecl*)(Args...)>(address)(args...);
 }
 
-template <typename Ret, unsigned int address, typename... Args> Ret CallAndReturn(Args... args) {
+template <typename Ret, unsigned int address, typename... Args>  Ret CallAndReturn(Args... args) {
     return reinterpret_cast<Ret(__cdecl*)(Args...)>(address)(args...);
 }
 
-template <unsigned int address, typename C, typename... Args> void CallMethod(C _this, Args... args) {
-    reinterpret_cast<void(__thiscall*)(C, Args...)>(address)(_this, args...);
-}
-
-template <typename Ret, unsigned int address, typename C, typename... Args> Ret CallMethodAndReturn(C _this, Args... args) {
+template <typename Ret, unsigned int address, typename C, typename... Args>
+Ret CallMethodAndReturn(C _this, Args... args) requires std::is_class_v<std::remove_pointer_t<C>> {
     return reinterpret_cast<Ret(__thiscall*)(C, Args...)>(address)(_this, args...);
 }
 
-template <unsigned int tableIndex, typename C, typename... Args> void CallVirtualMethod(C _this, Args... args) {
+template <unsigned int address, typename C, typename... Args>
+void CallMethod(C _this, Args... args) requires std::is_class_v<std::remove_pointer_t<C>> {
+    return reinterpret_cast<void(__thiscall*)(C, Args...)>(address)(_this, args...);
+}
+
+template <unsigned int tableIndex, typename C, typename... Args>
+void CallVirtualMethod(C _this, Args... args) requires std::is_class_v<std::remove_pointer_t<C>> {
     reinterpret_cast<void(__thiscall*)(C, Args...)>((*reinterpret_cast<void***>(_this))[tableIndex])(_this, args...);
 }
 
-template <typename Ret, unsigned int tableIndex, typename C, typename... Args> Ret CallVirtualMethodAndReturn(C _this, Args... args) {
+template <typename Ret, unsigned int tableIndex, typename C, typename... Args>
+Ret CallVirtualMethodAndReturn(C _this, Args... args) requires std::is_class_v<std::remove_pointer_t<C>> {
     return reinterpret_cast<Ret(__thiscall*)(C, Args...)>((*reinterpret_cast<void***>(_this))[tableIndex])(_this, args...);
 }
 

--- a/source/game_sa/Acquaintance.cpp
+++ b/source/game_sa/Acquaintance.cpp
@@ -56,5 +56,5 @@ void CAcquaintance::SetAsAcquaintance(AcquaintanceId id, uint32 pedTypeBitNum) {
 
 // 0x608980
 void CAcquaintance::ClearAsAcquaintance(AcquaintanceId id, uint32 pedTypeBitNum) {
-    plugin::CallMethod<0x608980, CAcquaintance*, AcquaintanceId, int32>(this, id, pedTypeBitNum);
+    plugin::CallMethod<0x608980>(this, id, pedTypeBitNum);
 }

--- a/source/game_sa/Audio/entities/AEPedSpeechAudioEntity.cpp
+++ b/source/game_sa/Audio/entities/AEPedSpeechAudioEntity.cpp
@@ -326,7 +326,7 @@ void CAEPedSpeechAudioEntity::StopCurrentSpeech() {
 
 // 0x4E4400
 int8 CAEPedSpeechAudioEntity::GetSoundAndBankIDsForScriptedSpeech(int32 a2) {
-    return plugin::CallMethodAndReturn<int8, 0x4E4400>(this, a2);
+    return plugin::CallMethodAndReturn<int8, 0x4E4400, CAEPedSpeechAudioEntity*, int32>(this, a2);
 }
 
 // 0x4E4200
@@ -341,7 +341,7 @@ bool CAEPedSpeechAudioEntity::GetPedTalking() {
 
 // 0x4E4170
 int8 CAEPedSpeechAudioEntity::GetVoiceAndTypeForSpecialPed(uint32 modelNameHash) {
-    return plugin::CallMethodAndReturn<int8, 0x4E4170>(this, modelNameHash);
+    return plugin::CallMethodAndReturn<int8, 0x4E4170, CAEPedSpeechAudioEntity*, uint32>(this, modelNameHash);
 }
 
 // Virtual methods// 0x4E3520

--- a/source/game_sa/Audio/entities/AEPedSpeechAudioEntity.cpp
+++ b/source/game_sa/Audio/entities/AEPedSpeechAudioEntity.cpp
@@ -218,7 +218,7 @@ int32 CAEPedSpeechAudioEntity::GetRepeatTime(int16 a1) {
 
 // 0x4E4840
 void CAEPedSpeechAudioEntity::LoadAndPlaySpeech(uint32 a2) {
-    plugin::CallMethod<0x4E4840, uint32>(a2);
+    plugin::CallMethod<0x4E4840>(this, a2);
 }
 
 // 0x4E49B0
@@ -228,12 +228,12 @@ int32 CAEPedSpeechAudioEntity::GetNumSlotsPlayingContext(int16 a2) {
 
 // 0x4E49E0
 int32 CAEPedSpeechAudioEntity::GetNextPlayTime(int16 a2) {
-    return plugin::CallMethodAndReturn<int32, 0x4E49E0, int16>(a2);
+    return plugin::CallMethodAndReturn<int32, 0x4E49E0>(this, a2);
 }
 
 // 0x4E4A20
 void CAEPedSpeechAudioEntity::SetNextPlayTime(int16 a2) {
-    plugin::CallMethod<0x4E4A20, int16>(a2);
+    plugin::CallMethod<0x4E4A20>(this, a2);
 }
 
 // 0x4E56D0
@@ -256,7 +256,7 @@ void CAEPedSpeechAudioEntity::DisablePedSpeechForScriptSpeech(int16 a1) {
 
 // 0x4E5730
 int8 CAEPedSpeechAudioEntity::CanPedSayGlobalContext(int16 a2) {
-    return plugin::CallMethodAndReturn<int8, 0x4E5730, int16>(a2);
+    return plugin::CallMethodAndReturn<int8, 0x4E5730>(this, a2);
 }
 
 // 0x4E58C0
@@ -279,17 +279,17 @@ int8 CAEPedSpeechAudioEntity::GetVoiceAndTypeFromModel(eModelID modelId) {
 
 // 0x4E5920
 int16 CAEPedSpeechAudioEntity::GetSoundAndBankIDs(int16 phraseId, int16* a3) {
-    return plugin::CallMethodAndReturn<int16, 0x4E5920, int16, int16*>(phraseId, a3);
+    return plugin::CallMethodAndReturn<int16, 0x4E5920>(this, phraseId, a3);
 }
 
 // 0x4E5F10
 bool CAEPedSpeechAudioEntity::CanWePlayGlobalSpeechContext(int16 a2) {
-    return plugin::CallMethodAndReturn<bool, 0x4E5F10, int16>(a2);
+    return plugin::CallMethodAndReturn<bool, 0x4E5F10>(this, a2);
 }
 
 // 0x4E6550
 int16 CAEPedSpeechAudioEntity::AddSayEvent(int32 a2, int16 phraseId, uint32 a4, float a5, uint8 a6, uint8 a7, uint8 a8) {
-    return plugin::CallMethodAndReturn<int16, 0x4E6550, int32, int16, uint32, float, uint8, uint8, uint8>(a2, phraseId, a4, a5, a6, a7, a8);
+    return plugin::CallMethodAndReturn<int16, 0x4E6550>(this, a2, phraseId, a4, a5, a6, a7, a8);
 }
 
 // 0x4E68D0
@@ -326,7 +326,7 @@ void CAEPedSpeechAudioEntity::StopCurrentSpeech() {
 
 // 0x4E4400
 int8 CAEPedSpeechAudioEntity::GetSoundAndBankIDsForScriptedSpeech(int32 a2) {
-    return plugin::CallMethodAndReturn<int8, 0x4E4400, int32>(a2);
+    return plugin::CallMethodAndReturn<int8, 0x4E4400>(this, a2);
 }
 
 // 0x4E4200
@@ -341,7 +341,7 @@ bool CAEPedSpeechAudioEntity::GetPedTalking() {
 
 // 0x4E4170
 int8 CAEPedSpeechAudioEntity::GetVoiceAndTypeForSpecialPed(uint32 modelNameHash) {
-    return plugin::CallMethodAndReturn<int8, 0x4E4170, uint32>(modelNameHash);
+    return plugin::CallMethodAndReturn<int8, 0x4E4170>(this, modelNameHash);
 }
 
 // Virtual methods// 0x4E3520

--- a/source/game_sa/Audio/entities/AEVehicleAudioEntity.cpp
+++ b/source/game_sa/Audio/entities/AEVehicleAudioEntity.cpp
@@ -209,7 +209,7 @@ void CAEVehicleAudioEntity::UpdateParameters_Reversed(CAESound* sound, int16 cur
 }
 
 void CAEVehicleAudioEntity::AddAudioEvent(eAudioEvents audioEvent, float fVolume) {
-    plugin::CallMethod<0x4F6420>(this, audioEvent, fVolume);
+    plugin::CallMethod<0x4F6420, CAEVehicleAudioEntity*, eAudioEvents, float>(this, audioEvent, fVolume);
 }
 
 void CAEVehicleAudioEntity::Service() {

--- a/source/game_sa/Audio/entities/AEVehicleAudioEntity.cpp
+++ b/source/game_sa/Audio/entities/AEVehicleAudioEntity.cpp
@@ -209,7 +209,7 @@ void CAEVehicleAudioEntity::UpdateParameters_Reversed(CAESound* sound, int16 cur
 }
 
 void CAEVehicleAudioEntity::AddAudioEvent(eAudioEvents audioEvent, float fVolume) {
-    plugin::CallMethod<0x4F6420, CAEVehicleAudioEntity*, int32, float>(this, audioEvent, fVolume);
+    plugin::CallMethod<0x4F6420>(this, audioEvent, fVolume);
 }
 
 void CAEVehicleAudioEntity::Service() {

--- a/source/game_sa/Audio/hardware/AEAudioHardware.cpp
+++ b/source/game_sa/Audio/hardware/AEAudioHardware.cpp
@@ -139,7 +139,7 @@ void CAEAudioHardware::SetChannelVolume(int16 channel, uint16 channelId, float v
 // 0x4D88A0
 bool CAEAudioHardware::LoadSoundBank(uint16 bankId, int16 bankSlotId) {
     if (!m_bDisableEffectsLoading) {
-        return plugin::CallMethodAndReturn<bool, 0x4E0670, void*, uint16, int16>(m_pMP3BankLoader, bankId, bankSlotId);
+        return plugin::CallMethodAndReturn<bool, 0x4E0670>(m_pMP3BankLoader, bankId, bankSlotId);
         // todo: return m_pMP3BankLoader->LoadSoundBank(bankId, bankSlotId);
     }
 
@@ -161,7 +161,7 @@ int8 CAEAudioHardware::GetSoundBankLoadingStatus(uint16 bankId, int16 bankSlotId
 // 0x4D8ED0
 bool CAEAudioHardware::LoadSound(uint16 bank, uint16 sound, int16 slot) {
     if (!m_bDisableEffectsLoading) {
-        return plugin::CallMethodAndReturn<bool, 0x4E07A0, void*, uint16, uint16, int16>(m_pMP3BankLoader, bank, sound, slot);
+        return plugin::CallMethodAndReturn<bool, 0x4E07A0>(m_pMP3BankLoader, bank, sound, slot);
         // todo: return m_pMP3BankLoader->LoadSound(bank, sound, slot);
     }
 

--- a/source/game_sa/Audio/hardware/AEStreamingChannel.cpp
+++ b/source/game_sa/Audio/hardware/AEStreamingChannel.cpp
@@ -49,7 +49,7 @@ uint32 CAEStreamingChannel::FillBuffer(void* buffer, uint32 size) {
 
 // 0x4F23D0
 void CAEStreamingChannel::PrepareStream(CAEStreamingDecoder* stream, int8 arg2, bool bStopCurrent) {
-    plugin::CallMethod<0x4F23D0>(this, stream, arg2, bStopCurrent);
+    plugin::CallMethod<0x4F23D0, CAEStreamingChannel*, CAEStreamingDecoder*, int8, bool>(this, stream, arg2, bStopCurrent);
 }
 
 // 0x4F1DE0

--- a/source/game_sa/Audio/hardware/AEStreamingChannel.cpp
+++ b/source/game_sa/Audio/hardware/AEStreamingChannel.cpp
@@ -49,7 +49,7 @@ uint32 CAEStreamingChannel::FillBuffer(void* buffer, uint32 size) {
 
 // 0x4F23D0
 void CAEStreamingChannel::PrepareStream(CAEStreamingDecoder* stream, int8 arg2, bool bStopCurrent) {
-    plugin::CallMethod<0x4F23D0, CAEStreamingChannel*, CAEStreamingDecoder*, char, bool>(this, stream, arg2, bStopCurrent);
+    plugin::CallMethod<0x4F23D0>(this, stream, arg2, bStopCurrent);
 }
 
 // 0x4F1DE0

--- a/source/game_sa/BreakObject_c.cpp
+++ b/source/game_sa/BreakObject_c.cpp
@@ -65,5 +65,5 @@ void BreakObject_c::Update(float timeStep) {
 
 // 0x59E480
 void BreakObject_c::Render(bool a1) {
-    plugin::CallMethod<0x59E480, BreakObject_c*, uint8>(this, a1);
+    plugin::CallMethod<0x59E480>(this, a1);
 }

--- a/source/game_sa/BreakObject_c.cpp
+++ b/source/game_sa/BreakObject_c.cpp
@@ -65,5 +65,5 @@ void BreakObject_c::Update(float timeStep) {
 
 // 0x59E480
 void BreakObject_c::Render(bool a1) {
-    plugin::CallMethod<0x59E480>(this, a1);
+    plugin::CallMethod<0x59E480, BreakObject_c*>(this, a1);
 }

--- a/source/game_sa/IKChainManager_c.cpp
+++ b/source/game_sa/IKChainManager_c.cpp
@@ -40,7 +40,7 @@ void IKChainManager_c::Reset() {
 
 // 0x6186D0
 void IKChainManager_c::Update(float a1) {
-    return plugin::CallMethod<0x6186D0, float>(a1);
+    return plugin::CallMethod<0x6186D0>(this, a1);
 }
 
 // 0x618750
@@ -85,7 +85,7 @@ bool IKChainManager_c::CanAcceptLookAt(CPed* ped) {
 
 // 0x618970
 void IKChainManager_c::LookAt(Const char* name, CPed* ped, CEntity* targetEntity, int32 time, ePedBones pedBoneId, CVector* posn, bool bArg7, float fSpeed, int32 blendTime, int32 a10, bool bForceLooking) {
-    plugin::CallMethod<0x618970, IKChainManager_c*, Const char*, CPed*, CEntity*, int32, int32, CVector*, bool, float, int32, int32, bool>(this, name, ped, targetEntity, time, pedBoneId, posn, bArg7, fSpeed, blendTime, a10, bForceLooking);
+    plugin::CallMethod<0x618970>(this, name, ped, targetEntity, time, pedBoneId, posn, bArg7, fSpeed, blendTime, a10, bForceLooking);
 }
 
 bool IKChainManager_c::IsArmPointing(int32 nSlot, CPed* ped) {

--- a/source/game_sa/IKChainManager_c.cpp
+++ b/source/game_sa/IKChainManager_c.cpp
@@ -40,7 +40,7 @@ void IKChainManager_c::Reset() {
 
 // 0x6186D0
 void IKChainManager_c::Update(float a1) {
-    return plugin::CallMethod<0x6186D0>(this, a1);
+    return plugin::CallMethod<0x6186D0, IKChainManager_c*>(this, a1);
 }
 
 // 0x618750
@@ -85,7 +85,7 @@ bool IKChainManager_c::CanAcceptLookAt(CPed* ped) {
 
 // 0x618970
 void IKChainManager_c::LookAt(Const char* name, CPed* ped, CEntity* targetEntity, int32 time, ePedBones pedBoneId, CVector* posn, bool bArg7, float fSpeed, int32 blendTime, int32 a10, bool bForceLooking) {
-    plugin::CallMethod<0x618970>(this, name, ped, targetEntity, time, pedBoneId, posn, bArg7, fSpeed, blendTime, a10, bForceLooking);
+    plugin::CallMethod<0x618970, IKChainManager_c*, const char*, CPed*, CEntity*, int32, ePedBones, CVector*, bool, float, int32, int32, bool>(this, name, ped, targetEntity, time, pedBoneId, posn, bArg7, fSpeed, blendTime, a10, bForceLooking);
 }
 
 bool IKChainManager_c::IsArmPointing(int32 nSlot, CPed* ped) {
@@ -99,7 +99,7 @@ void IKChainManager_c::AbortPointArm(int32 a1, CPed* ped, int32 a3) {
 
 // 0x618330
 bool IKChainManager_c::IsFacingTarget(CPed* ped, int32 a2) {
-    return plugin::CallMethodAndReturn<bool, 0x0, IKChainManager_c*, CPed*, int32>(this, ped, a2);
+    return plugin::CallMethodAndReturn<bool, 0x618330, IKChainManager_c*, CPed*, int32>(this, ped, a2);
 }
 
 // 0x618B60

--- a/source/game_sa/PedClothesDesc.cpp
+++ b/source/game_sa/PedClothesDesc.cpp
@@ -1,15 +1,18 @@
 #include "StdInc.h"
 
+#include "PedClothesDesc.h"
+
 void CPedClothesDesc::InjectHooks() {
-    ReversibleHooks::Install("CPedClothesDesc", "CPedClothesDesc", 0x5A8020, &CPedClothesDesc::Constructor);
-//    ReversibleHooks::Install("CPedClothesDesc", "Initialise", 0x5A78F0, &CPedClothesDesc::Initialise);
-//    ReversibleHooks::Install("CPedClothesDesc", "GetIsWearingBalaclava", 0x5A7950, &CPedClothesDesc::GetIsWearingBalaclava);
-//    ReversibleHooks::Install("CPedClothesDesc", "HasVisibleNewHairCut", 0x5A7970, &CPedClothesDesc::HasVisibleNewHairCut);
-//    ReversibleHooks::Install("CPedClothesDesc", "HasVisibleTattoo", 0x5A79D0, &CPedClothesDesc::HasVisibleTattoo);
+    using namespace ReversibleHooks;
+    Install("CPedClothesDesc", "CPedClothesDesc", 0x5A8020, &CPedClothesDesc::Constructor);
+    Install("CPedClothesDesc", "Initialise", 0x5A78F0, &CPedClothesDesc::Initialise);
+    Install("CPedClothesDesc", "GetIsWearingBalaclava", 0x5A7950, &CPedClothesDesc::GetIsWearingBalaclava);
+    Install("CPedClothesDesc", "HasVisibleNewHairCut", 0x5A7970, &CPedClothesDesc::HasVisibleNewHairCut);
+    Install("CPedClothesDesc", "HasVisibleTattoo", 0x5A79D0, &CPedClothesDesc::HasVisibleTattoo);
 }
 
 CPedClothesDesc::CPedClothesDesc() {
-    memset(m_anTextureKeys, 0, sizeof(m_anTextureKeys));
+    std::ranges::fill(m_anTextureKeys, 0);
     m_fFatStat = 0.0f;
     m_fMuscleStat = 0.0f;
 }
@@ -19,34 +22,42 @@ CPedClothesDesc* CPedClothesDesc::Constructor() {
     return this;
 }
 
+// 0x5A78F0
 void CPedClothesDesc::Initialise() {
     plugin::CallMethod<0x5A78F0, CPedClothesDesc*>(this);
 }
 
+// 0x5A7910
 void CPedClothesDesc::SetModel(uint32 modelId, eClothesModelPart modelPart) {
     plugin::CallMethod<0x5A7910, CPedClothesDesc*, uint32, eClothesModelPart>(this, modelId, modelPart);
 }
 
+// 0x5A7920
 void CPedClothesDesc::SetModel(const char* model, eClothesModelPart modelPart) {
     plugin::CallMethod<0x5A7920, CPedClothesDesc*, const char*, eClothesModelPart>(this, model, modelPart);
 }
 
+// 0x5A7950
 bool CPedClothesDesc::GetIsWearingBalaclava() {
-    return plugin::CallMethodAndReturn<bool, 0x5A7950>(this);
+    return plugin::CallMethodAndReturn<bool, 0x5A7950, CPedClothesDesc*>(this);
 }
 
+// 0x5A7970
 bool CPedClothesDesc::HasVisibleNewHairCut(int32 arg1) {
-    return plugin::CallMethodAndReturn<bool, 0x5A7970>(this, arg1);
+    return plugin::CallMethodAndReturn<bool, 0x5A7970, CPedClothesDesc*, int32>(this, arg1);
 }
 
+// 0x5A79D0
 bool CPedClothesDesc::HasVisibleTattoo() {
-    return plugin::CallMethodAndReturn<bool, 0x5A79D0>(this);
+    return plugin::CallMethodAndReturn<bool, 0x5A79D0, CPedClothesDesc*>(this);
 }
 
+// 0x5A8050
 void CPedClothesDesc::SetTextureAndModel(uint32 texture, uint32 model, eClothesTexturePart texturePart) {
     plugin::CallMethod<0x5A8050, CPedClothesDesc*, uint32, uint32, eClothesTexturePart>(this, texture, model, texturePart);
 }
 
+// 0x5A8080
 void CPedClothesDesc::SetTextureAndModel(const char* textureName, const char* modelName, eClothesTexturePart texturePart) {
     plugin::CallMethod<0x5A8080, CPedClothesDesc*, const char*, const char*, eClothesTexturePart>(this, textureName, modelName, texturePart);
 }

--- a/source/game_sa/PedClothesDesc.cpp
+++ b/source/game_sa/PedClothesDesc.cpp
@@ -36,7 +36,7 @@ bool CPedClothesDesc::GetIsWearingBalaclava() {
 }
 
 bool CPedClothesDesc::HasVisibleNewHairCut(int32 arg1) {
-    return plugin::CallMethodAndReturn<bool, 0x5A7970, int32>(arg1);
+    return plugin::CallMethodAndReturn<bool, 0x5A7970>(this, arg1);
 }
 
 bool CPedClothesDesc::HasVisibleTattoo() {

--- a/source/game_sa/ProjectileInfo.cpp
+++ b/source/game_sa/ProjectileInfo.cpp
@@ -79,10 +79,7 @@ bool CProjectileInfo::RemoveIfThisIsAProjectile(CObject* object) {
     return plugin::CallAndReturn<bool, 0x739A40, CObject*>(object);
 }
 
-// Methods
 // 0x737B80
-void CProjectileInfo::RemoveFXSystem(uint8 bInstantly) {
-    plugin::Call<0x737B80>(bInstantly);
+void CProjectileInfo::RemoveFXSystem(bool bInstantly) {
+    plugin::CallMethod<0x737B80, CProjectileInfo*, bool>(this, bInstantly);
 }
-
-// Virtual methods

--- a/source/game_sa/ProjectileInfo.cpp
+++ b/source/game_sa/ProjectileInfo.cpp
@@ -82,7 +82,7 @@ bool CProjectileInfo::RemoveIfThisIsAProjectile(CObject* object) {
 // Methods
 // 0x737B80
 void CProjectileInfo::RemoveFXSystem(uint8 bInstantly) {
-    plugin::CallMethod<0x737B80, uint8>(bInstantly);
+    plugin::Call<0x737B80>(bInstantly);
 }
 
 // Virtual methods

--- a/source/game_sa/ProjectileInfo.h
+++ b/source/game_sa/ProjectileInfo.h
@@ -30,7 +30,7 @@ public:
 
     static void Initialise();
     static void Shutdown();
-    static void RemoveFXSystem(bool bInstantly);
+    void RemoveFXSystem(bool bInstantly);
     static CProjectileInfo* GetProjectileInfo(int32 infoId);
     static void RemoveNotAdd(CEntity* creator, eWeaponType weaponType, CVector posn);
     static bool AddProjectile(CEntity* creator, eWeaponType eWeaponType, CVector posn, float force, CVector* direction, CEntity* victim);

--- a/source/game_sa/ProjectileInfo.h
+++ b/source/game_sa/ProjectileInfo.h
@@ -29,8 +29,8 @@ public:
     static void InjectHooks();
 
     static void Initialise();
-    static void RemoveFXSystem(uint8 bInstantly);
     static void Shutdown();
+    static void RemoveFXSystem(bool bInstantly);
     static CProjectileInfo* GetProjectileInfo(int32 infoId);
     static void RemoveNotAdd(CEntity* creator, eWeaponType weaponType, CVector posn);
     static bool AddProjectile(CEntity* creator, eWeaponType eWeaponType, CVector posn, float force, CVector* direction, CEntity* victim);

--- a/source/game_sa/Scripts/RunningScript.cpp
+++ b/source/game_sa/Scripts/RunningScript.cpp
@@ -232,7 +232,7 @@ void CRunningScript::FlameInAngledAreaCheckCommand(int32 commandId) {
 
 // 0x464F50
 void CRunningScript::GetCorrectPedModelIndexForEmergencyServiceType(ePedType pedType, int32* pModelId) {
-    plugin::CallMethod<0x464F50, ePedType, int32*>(pedType, pModelId);
+    plugin::CallMethod<0x464F50>(this, pedType, pModelId);
 }
 
 // Returns offset of global variable

--- a/source/game_sa/Scripts/RunningScript.cpp
+++ b/source/game_sa/Scripts/RunningScript.cpp
@@ -232,7 +232,7 @@ void CRunningScript::FlameInAngledAreaCheckCommand(int32 commandId) {
 
 // 0x464F50
 void CRunningScript::GetCorrectPedModelIndexForEmergencyServiceType(ePedType pedType, int32* pModelId) {
-    plugin::CallMethod<0x464F50>(this, pedType, pModelId);
+    plugin::CallMethod<0x464F50, CRunningScript*, ePedType, int32*>(this, pedType, pModelId);
 }
 
 // Returns offset of global variable

--- a/source/game_sa/UpsideDownCarCheck.cpp
+++ b/source/game_sa/UpsideDownCarCheck.cpp
@@ -32,12 +32,12 @@ bool CUpsideDownCarCheck::AreAnyCarsUpsideDown() {
 
 // 0x4638D0
 void CUpsideDownCarCheck::AddCarToCheck(int32 carHandle) {
-    plugin::CallMethod<0x4638D0, int32>(carHandle);
+    plugin::CallMethod<0x4638D0>(this, carHandle);
 }
 
 // 0x463910
 void CUpsideDownCarCheck::RemoveCarFromCheck(int32 carHandle) {
-    plugin::CallMethod<0x463910, int32>(carHandle);
+    plugin::CallMethod<0x463910>(this, carHandle);
 }
 
 // 0x463940

--- a/source/game_sa/UpsideDownCarCheck.cpp
+++ b/source/game_sa/UpsideDownCarCheck.cpp
@@ -32,12 +32,12 @@ bool CUpsideDownCarCheck::AreAnyCarsUpsideDown() {
 
 // 0x4638D0
 void CUpsideDownCarCheck::AddCarToCheck(int32 carHandle) {
-    plugin::CallMethod<0x4638D0>(this, carHandle);
+    plugin::CallMethod<0x4638D0, CUpsideDownCarCheck*, int32>(this, carHandle);
 }
 
 // 0x463910
 void CUpsideDownCarCheck::RemoveCarFromCheck(int32 carHandle) {
-    plugin::CallMethod<0x463910>(this, carHandle);
+    plugin::CallMethod<0x463910, CUpsideDownCarCheck*, int32>(this, carHandle);
 }
 
 // 0x463940


### PR DESCRIPTION
So there was a little issue we have had, which lead to this.
This way `CallMethod` can't be called with incorrect first argument.