### PR TITLE
Fix CStreaming list iters

### DIFF
--- a/source/game_sa/Streaming.cpp
+++ b/source/game_sa/Streaming.cpp
@@ -912,7 +912,9 @@ void CStreaming::DeleteRwObjectsBehindCamera(int32 memoryToCleanInBytes) {
 
 // 0x409940
 bool CStreaming::DeleteRwObjectsBehindCameraInSectorList(CPtrList& list, int32 memoryToCleanInBytes) {
-    for (CPtrNode* node = list.GetNode(); node; node = node->m_next) {
+    for (CPtrNode* node = list.GetNode(), *next{}; node; node = next) {
+        next = node->GetNext();
+
         CEntity* entity = static_cast<CEntity*>(node->m_item);
         if (entity->m_nScanCode == GetCurrentScanCode())
             continue;
@@ -938,7 +940,9 @@ bool CStreaming::DeleteRwObjectsBehindCameraInSectorList(CPtrList& list, int32 m
 
 // 0x407A70
 void CStreaming::DeleteRwObjectsInSectorList(CPtrList& list, int32 sectorX, int32 sectorY) {
-    for (CPtrNode* node = list.GetNode(); node; node = node->m_next) {
+    for (CPtrNode* node = list.GetNode(), *next{}; node; node = next) {
+        next = node->GetNext();
+
         CEntity* entity = reinterpret_cast<CEntity*>(node->m_item);
         if (sectorX < 0 || entity->LivesInThisNonOverlapSector(sectorX, sectorY)) {
             if (!entity->m_bImBeingRendered && !entity->m_bStreamingDontDelete)
@@ -949,7 +953,9 @@ void CStreaming::DeleteRwObjectsInSectorList(CPtrList& list, int32 sectorX, int3
 
 // 0x4099E0
 bool CStreaming::DeleteRwObjectsNotInFrustumInSectorList(CPtrList& list, int32 memoryToCleanInBytes) {
-    for (CPtrNode* node = list.GetNode(); node; node = node->m_next) {
+    for (CPtrNode* node = list.GetNode(), *next{}; node; node = next) {
+        next = node->GetNext();
+
         CEntity* entity = reinterpret_cast<CEntity*>(node->m_item);
         if (entity->m_nScanCode == GetCurrentScanCode())
             continue;
@@ -2474,7 +2480,9 @@ void CStreaming::MakeSpaceFor(int32 memoryToCleanInBytes)
 // - In the radius of min(radius, <model draw distance> * <cam lod dist multiplier>)
 void CStreaming::ProcessEntitiesInSectorList(CPtrList& list, float posX, float posY, float minX, float minY, float maxX, float maxY, float radius, int32 streamingflags) {
     CVector2D position(posX, posY);
-    for (CPtrNode* node = list.GetNode(); node; node = node->m_next) {
+    for (CPtrNode* node = list.GetNode(), *next{}; node; node = next) {
+        next = node->GetNext();
+
         CEntity* entity = reinterpret_cast<CEntity*>(node->m_item);
 
         if (entity->m_nScanCode == GetCurrentScanCode())
@@ -2517,7 +2525,9 @@ void CStreaming::ProcessEntitiesInSectorList(CPtrList& list, float posX, float p
 // unlike the above function (other overload) this one doesn't do radius checks
 // just requests all models necessary (if they meet the conditions).
 void CStreaming::ProcessEntitiesInSectorList(CPtrList& list, int32 streamingFlags) {
-    for (CPtrNode* node = list.GetNode(); node; node = node->m_next) {
+    for (CPtrNode* node = list.GetNode(), *next{}; node; node = next) {
+        next = node->GetNext();
+
         CEntity* entity = reinterpret_cast<CEntity*>(node->m_item);
         if (entity->m_nScanCode == GetCurrentScanCode())
             continue;
@@ -2897,7 +2907,9 @@ void CStreaming::InstanceLoadedModels(CVector const& point) {
 
 void CStreaming::InstanceLoadedModelsInSectorList(CPtrList& list)
 {
-    for (CPtrNode* node = list.GetNode(); node; node = node->m_next) {
+    for (CPtrNode* node = list.GetNode(), *next{}; node; node = next) {
+        next = node->GetNext();
+
         CEntity* entity = reinterpret_cast<CEntity*>(node->m_item);
         if (entity->IsInCurrentAreaOrBarberShopInterior() && !entity->m_pRwObject)
             entity->CreateRwObject();


### PR DESCRIPTION
The `next` value from the node has to be saved because when the entity it belongs to is removed it's invalidated as well.
