### PR TITLE
Fix missing namespace for GetLetterIdPropValue

### DIFF
--- a/source/game_sa/Font.cpp
+++ b/source/game_sa/Font.cpp
@@ -85,7 +85,7 @@ void CFont::InjectHooks() {
     Install("CFont", "LoadFontValues", 0x7187C0, &CFont::LoadFontValues);
     // Install("", "GetScriptLetterSize", 0x719670, &GetScriptLetterSize);
     // Install("", "GetIDforPropVal", 0x7192C0, &GetIDforPropVal);
-    Install("", "GetLetterIdPropValue", 0x718770, &GetLetterIdPropValue);
+    Install("CFont", "GetLetterIdPropValue", 0x718770, &GetLetterIdPropValue);
 }
 
 // 0x7187C0


### PR DESCRIPTION
Fixes this (Notice how it has no namespace):
![image](https://user-images.githubusercontent.com/12902714/150682584-4f2d0ca8-12dc-441b-af9a-6164be150547.png)
