### PR TITLE
Improve reversible hooks stability, fix static field size issue

### DIFF
--- a/source/game_sa/GameLogic.h
+++ b/source/game_sa/GameLogic.h
@@ -2,7 +2,7 @@
 
 #include "Vector.h"
 
-enum eGameState : unsigned char {
+enum eGameState : uint8 {
     GAME_STATE_INITIAL = 0,
     GAME_STATE_LOGO = 1,
     GAME_STATE_PLAYING_LOGO = 2,

--- a/source/game_sa/GameLogic.h
+++ b/source/game_sa/GameLogic.h
@@ -2,7 +2,7 @@
 
 #include "Vector.h"
 
-enum eGameState {
+enum eGameState : unsigned char {
     GAME_STATE_INITIAL = 0,
     GAME_STATE_LOGO = 1,
     GAME_STATE_PLAYING_LOGO = 2,

--- a/source/game_sa/Plugins/CollisionPlugin/CollisionPlugin.cpp
+++ b/source/game_sa/Plugins/CollisionPlugin/CollisionPlugin.cpp
@@ -2,6 +2,7 @@
 
 #include "CollisionPlugin.h"
 
+RwInt32& gCollisionPluginOffset = *(RwInt32*)0x9689DC;
 CClumpModelInfo*& CCollisionPlugin::ms_currentModel = *(CClumpModelInfo**)0x9689E0;
 
 void CCollisionPlugin::InjectHooks() {
@@ -74,7 +75,7 @@ static RwInt32 ClumpCollisionGetSize(const void* object, RwInt32 offsetInObject,
 // 0x41B310
 bool CCollisionPlugin::PluginAttach() {
     // 0x9689DC unused
-    static RwInt32 CollisionPlugin = RpClumpRegisterPlugin(
+    gCollisionPluginOffset = RpClumpRegisterPlugin(
         0,
         rwID_COLLISIONPLUGIN,
         ClumpCollisionConstructor,

--- a/source/game_sa/Plugins/CollisionPlugin/CollisionPlugin.h
+++ b/source/game_sa/Plugins/CollisionPlugin/CollisionPlugin.h
@@ -9,6 +9,11 @@ class CClumpModelInfo;
  */
 #define rwID_COLLISIONPLUGIN  MAKECHUNKID(rwVENDORID_ROCKSTAR, 0xFA)
 
+/*
+* Collision plugin static offset
+*/
+extern RwInt32& gCollisionPluginOffset;
+
 class CCollisionPlugin {
 public:
     static CClumpModelInfo*& ms_currentModel;

--- a/source/game_sa/Plugins/NodeNamePlugin/NodeName.cpp
+++ b/source/game_sa/Plugins/NodeNamePlugin/NodeName.cpp
@@ -4,7 +4,7 @@
 
 #define NAME_LENGTH 23
 
-RwInt32 gPluginOffset;
+RwInt32& gNodeNamePluginOffset = *(RwInt32*)0xC87C5C;
 
 /**
  * NodeName plugin structure
@@ -28,8 +28,8 @@ void NodeNamePlugin::InjectHooks() {
 // internal
 // 0x72F9C0
 static void* NodeNameConstructor(void* object, RwInt32 offsetInObject, RwInt32 sizeInObject) {
-    if (gPluginOffset > 0)
-        RWPLUGINOFFSET(NodeNamePluginInstance, object, gPluginOffset)->name[0] = '\0';
+    if (gNodeNamePluginOffset > 0)
+        RWPLUGINOFFSET(NodeNamePluginInstance, object, gNodeNamePluginOffset)->name[0] = '\0';
 
     return object;
 }
@@ -43,54 +43,54 @@ static void* NodeNameDestructor(void* object, RwInt32 offsetInObject, RwInt32 si
 // internal
 // 0x72F9F0
 static void* NodeNameCopy(void* dstObject, const void* srcObject, RwInt32 offsetInObject, RwInt32 sizeInObject) {
-    strncpy(RWPLUGINOFFSET(NodeNamePluginInstance, dstObject, gPluginOffset)->name, RWPLUGINOFFSET(NodeNamePluginInstance, srcObject, gPluginOffset)->name, NAME_LENGTH);
+    strncpy(RWPLUGINOFFSET(NodeNamePluginInstance, dstObject, gNodeNamePluginOffset)->name, RWPLUGINOFFSET(NodeNamePluginInstance, srcObject, gNodeNamePluginOffset)->name, NAME_LENGTH);
     return dstObject;
 }
 
 // internal
 // 0x72FA50
 static RwStream* NodeNameStreamRead(RwStream* stream, RwInt32 binaryLength, void* object, RwInt32 offsetInObject, RwInt32 sizeInObject) {
-    RwStreamRead(stream, RWPLUGINOFFSET(NodeNamePluginInstance, object, gPluginOffset), binaryLength);
-    RWPLUGINOFFSET(NodeNamePluginInstance, object, gPluginOffset)->name[binaryLength] = 0;
+    RwStreamRead(stream, RWPLUGINOFFSET(NodeNamePluginInstance, object, gNodeNamePluginOffset), binaryLength);
+    RWPLUGINOFFSET(NodeNamePluginInstance, object, gNodeNamePluginOffset)->name[binaryLength] = 0;
     return stream;
 }
 
 // internal
 // 0x72FA20
 static RwStream* NodeNameStreamWrite(RwStream* stream, RwInt32 binaryLength, const void* object, RwInt32 offsetInObject, RwInt32 sizeInObject) {
-    RwStreamWrite(stream, RWPLUGINOFFSET(NodeNamePluginInstance, object, gPluginOffset), binaryLength);
+    RwStreamWrite(stream, RWPLUGINOFFSET(NodeNamePluginInstance, object, gNodeNamePluginOffset), binaryLength);
     return stream;
 }
 
 // internal
 // 0x72FA80
 static RwInt32 NodeNameStreamGetSize(const void* object, RwInt32 offsetInObject, RwInt32 sizeInObject) {
-    if (RWPLUGINOFFSET(NodeNamePluginInstance, object, gPluginOffset))
-        return strlen(RWPLUGINOFFSET(NodeNamePluginInstance, object, gPluginOffset)->name);
+    if (RWPLUGINOFFSET(NodeNamePluginInstance, object, gNodeNamePluginOffset))
+        return strlen(RWPLUGINOFFSET(NodeNamePluginInstance, object, gNodeNamePluginOffset)->name);
 
     return 0;
 }
 
 RwBool NodeNamePluginAttach() {
     // register plugin
-    gPluginOffset = RwFrameRegisterPlugin(sizeof(NodeNamePluginInstance), rwID_NODENAMEPLUGIN, NodeNameConstructor, NodeNameDestructor, NodeNameCopy);
+    gNodeNamePluginOffset = RwFrameRegisterPlugin(sizeof(NodeNamePluginInstance), rwID_NODENAMEPLUGIN, NodeNameConstructor, NodeNameDestructor, NodeNameCopy);
 
     // register stream operations
     RwFrameRegisterPluginStream(rwID_NODENAMEPLUGIN, NodeNameStreamRead, NodeNameStreamWrite, NodeNameStreamGetSize);
 
-    return gPluginOffset != -1;
+    return gNodeNamePluginOffset != -1;
 }
 
 const RwChar* GetFrameNodeName(RwFrame* frame) {
-    if (gPluginOffset > 0)
-        return RWPLUGINOFFSET(NodeNamePluginInstance, frame, gPluginOffset)->name;
+    if (gNodeNamePluginOffset > 0)
+        return RWPLUGINOFFSET(NodeNamePluginInstance, frame, gNodeNamePluginOffset)->name;
 
     return nullptr;
 }
 
 void SetFrameNodeName(RwFrame* frame, const RwChar* name) {
-    if (gPluginOffset > 0) {
-        strncpy(RWPLUGINOFFSET(NodeNamePluginInstance, frame, gPluginOffset)->name, name, NAME_LENGTH);
-        RWPLUGINOFFSET(NodeNamePluginInstance, frame, gPluginOffset)->name[NAME_LENGTH] = '\0';
+    if (gNodeNamePluginOffset > 0) {
+        strncpy(RWPLUGINOFFSET(NodeNamePluginInstance, frame, gNodeNamePluginOffset)->name, name, NAME_LENGTH);
+        RWPLUGINOFFSET(NodeNamePluginInstance, frame, gNodeNamePluginOffset)->name[NAME_LENGTH] = '\0';
     }
 }

--- a/source/game_sa/Plugins/NodeNamePlugin/NodeName.h
+++ b/source/game_sa/Plugins/NodeNamePlugin/NodeName.h
@@ -22,9 +22,14 @@ void InjectHooks();
 }
 
 /**
- * NodePlugin unique rwID
+ * NodeNamePlugin unique rwID
  */
 #define rwID_NODENAMEPLUGIN MAKECHUNKID(rwVENDORID_ROCKSTAR, 0xFE)
+
+/*
+* NodeName plugin static offset
+*/
+extern RwInt32& gNodeNamePluginOffset;
 
 /**
  * Attach NodeName plugin

--- a/source/game_sa/Plugins/PipelinePlugin/PipelinePlugin.cpp
+++ b/source/game_sa/Plugins/PipelinePlugin/PipelinePlugin.cpp
@@ -4,6 +4,9 @@
 
 #include <rpworld.h>
 
+ RwInt32& gPipelinePluginOffset = *(RwInt32*)0x8D6080;
+
+
 void PipelinePlugin::InjectHooks() {
     RH_ScopedNamespace(PipelinePlugin);
     RH_ScopedCategory("Plugins");
@@ -15,10 +18,6 @@ void PipelinePlugin::InjectHooks() {
 }
 
 // internal
-// 0x8D6080
-static RwUInt32 gAtomicOffset = -1;
-
-// internal
 typedef struct tPipelinePlugin {
     RwUInt32 pipelineId;
 } PipelinePluginInstance;
@@ -28,7 +27,7 @@ VALIDATE_SIZE(tPipelinePlugin, 0x4);
 // internal
 // 0x72FB50
 static void* PipelineConstructor(void* object, RwInt32 offsetInObject, RwInt32 sizeInObject) {
-    if (gAtomicOffset > 0) {
+    if (gPipelinePluginOffset > 0) {
         RWPLUGINOFFSET(tPipelinePlugin, object, offsetInObject)->pipelineId = 0;
     }
     return object;
@@ -44,7 +43,7 @@ static void* PipelineCopy(void* dstObject, const void* srcObject, RwInt32 offset
 // internal
 // 0x72FB90
 static RwStream* PipelineStreamRead(RwStream* stream, RwInt32 binaryLength, void* object, RwInt32 offsetInObject, RwInt32 sizeInObject) {
-    RwStreamRead(stream, RWPLUGINOFFSET(tPipelinePlugin, object, gAtomicOffset), binaryLength);
+    RwStreamRead(stream, RWPLUGINOFFSET(tPipelinePlugin, object, gPipelinePluginOffset), binaryLength);
     return stream;
 }
 
@@ -62,12 +61,12 @@ static RwStream* PipelineStreamWrite(RwStream* stream, RwInt32 binaryLength, voi
 
 // 0x72FBD0
 RwBool PipelinePluginAttach() {
-    gAtomicOffset = RpAtomicRegisterPlugin(sizeof(tPipelinePlugin), rwID_PIPELINEPLUGIN, PipelineConstructor, nullptr, PipelineCopy);
-    if (gAtomicOffset == -1) {
+    gPipelinePluginOffset = RpAtomicRegisterPlugin(sizeof(tPipelinePlugin), rwID_PIPELINEPLUGIN, PipelineConstructor, nullptr, PipelineCopy);
+    if (gPipelinePluginOffset == -1) {
         return FALSE;
     }
     if (RpAtomicRegisterPluginStream(rwID_PIPELINEPLUGIN, PipelineStreamRead, PipelineStreamWrite, PipelineGetSize) == -1) {
-        gAtomicOffset = -1;
+        gPipelinePluginOffset = -1;
         return FALSE;
     }
     return TRUE;
@@ -75,10 +74,10 @@ RwBool PipelinePluginAttach() {
 
 // 0x72FC40
 RwUInt32 GetPipelineID(RpAtomic* atomic) {
-    return RWPLUGINOFFSET(tPipelinePlugin, atomic, gAtomicOffset)->pipelineId;
+    return RWPLUGINOFFSET(tPipelinePlugin, atomic, gPipelinePluginOffset)->pipelineId;
 }
 
 // 0x72FC50
 void SetPipelineID(RpAtomic* atomic, RwUInt32 pipelineId) {
-    RWPLUGINOFFSET(tPipelinePlugin, atomic, gAtomicOffset)->pipelineId = pipelineId;
+    RWPLUGINOFFSET(tPipelinePlugin, atomic, gPipelinePluginOffset)->pipelineId = pipelineId;
 }

--- a/source/game_sa/Plugins/PipelinePlugin/PipelinePlugin.h
+++ b/source/game_sa/Plugins/PipelinePlugin/PipelinePlugin.h
@@ -28,6 +28,11 @@ void InjectHooks();
  */
 #define rwID_PIPELINEPLUGIN  MAKECHUNKID(rwVENDORID_ROCKSTAR, 0xF3)
 
+/*
+* Pipeline plugin static offset
+*/
+extern RwInt32& gPipelinePluginOffset;
+
 /**
  * Attach pipeline plugin
  *


### PR DESCRIPTION
1. eGameState was incorrectly read from memory as int, which causes various small issues like markers not working sometimes
2. RW Plugins work with reversible hooks now, greatly improving stability for unhooking/rehooking stuff