### PR TITLE
Vehicle* virtual funcs

### DIFF
--- a/source/InjectHooksMain.cpp
+++ b/source/InjectHooksMain.cpp
@@ -222,7 +222,6 @@ void InjectHooksMain() {
     CClothes::InjectHooks();
     CBulletInfo::InjectHooks();
     CRestart::InjectHooks();
-    CPlaneTrail::InjectHooks();
     CCopPed::InjectHooks();
     CDamageManager::InjectHooks();
     CCreepingFire::InjectHooks();
@@ -291,7 +290,6 @@ void InjectHooksMain() {
     CVisibilityPlugins::InjectHooks();
     CPed::InjectHooks();
     CPedIntelligence::InjectHooks();
-    CTrain::InjectHooks();
     CCollision::InjectHooks();
     CColSphere::InjectHooks();
     CColLine::InjectHooks();
@@ -323,10 +321,6 @@ void InjectHooksMain() {
     CEscalators::InjectHooks();
     CWeapon::InjectHooks();
     cTransmission::InjectHooks();
-    CVehicle::InjectHooks();
-    CAutomobile::InjectHooks();
-    CBike::InjectHooks();
-    CBoat::InjectHooks();
     CPlayerPed::InjectHooks();
     CStats::InjectHooks();
     CCarCtrl::InjectHooks();
@@ -407,11 +401,6 @@ void InjectHooksMain() {
     CLocalisation::InjectHooks();
     CSimpleVariablesSaveStructure::InjectHooks();
     CPedGeometryAnalyser::InjectHooks();
-    CPlane::InjectHooks();
-    CHeli::InjectHooks();
-    CBmx::InjectHooks();
-    CTrailer::InjectHooks();
-    CQuadBike::InjectHooks();
     NodeNamePlugin::InjectHooks();
     JPegPlugin::InjectHooks();
     PipelinePlugin::InjectHooks();
@@ -425,6 +414,7 @@ void InjectHooksMain() {
     CWaterCannons::InjectHooks();
     CWaterCannon::InjectHooks();
     CSprite::InjectHooks();
+    CPlaneTrail::InjectHooks();
     CPlaneTrails::InjectHooks();
     CCustomBuildingPipeline::InjectHooks();
     CCustomBuildingRenderer::InjectHooks();
@@ -652,10 +642,25 @@ void InjectHooksMain() {
         // FxSystem_c::InjectHooks();
     };
 
+    const auto Vehicle = []() {
+        CAutomobile::InjectHooks();
+        CBike::InjectHooks();
+        CBmx::InjectHooks();
+        CBoat::InjectHooks();
+        CHeli::InjectHooks();
+        CMonsterTruck::InjectHooks();
+        CPlane::InjectHooks();
+        CQuadBike::InjectHooks();
+        CTrailer::InjectHooks();
+        CTrain::InjectHooks();
+        CVehicle::InjectHooks();
+    };
+
     Audio();
     Tasks();
     Events();
     Fx();
+    Vehicle();
 
     ReversibleHooks::OnInjectionEnd();
 }

--- a/source/game_sa/Audio/managers/AERadioTrackManager.cpp
+++ b/source/game_sa/Audio/managers/AERadioTrackManager.cpp
@@ -206,7 +206,7 @@ void CAERadioTrackManager::DisplayRadioStationName() {
     if (TheCamera.m_bWideScreenOn)
         return;
 
-    if (!FindPlayerVehicle(-1, false))
+    if (!FindPlayerVehicle())
         return;
 
     if (CReplay::Mode == 1)

--- a/source/game_sa/CarGenerator.cpp
+++ b/source/game_sa/CarGenerator.cpp
@@ -239,11 +239,11 @@ void CCarGenerator::DoInternalProcessing()
             break;
         case VEHICLE_TYPE_BIKE:
             vehicle = new CBike(actualModelId, PARKED_VEHICLE);
-            vehicle->AsBike()->damageFlags.bDamageFlag4 = true;
+            vehicle->AsBike()->bikeFlags.bIsStanding = true;
             break;
         case VEHICLE_TYPE_BMX:
             vehicle = new CBmx(actualModelId, PARKED_VEHICLE);
-            vehicle->AsBike()->damageFlags.bDamageFlag4 = true;
+            vehicle->AsBike()->bikeFlags.bIsStanding = true;
             break;
         case VEHICLE_TYPE_TRAILER:
             vehicle = new CTrailer(actualModelId, PARKED_VEHICLE);

--- a/source/game_sa/Cheat.cpp
+++ b/source/game_sa/Cheat.cpp
@@ -554,7 +554,7 @@ void CCheat::HealthCheat() {
     vehicle->m_fHealth = 1000.0f;
     if (vehicle->IsBike()) {
         CBike* bike = vehicle->AsBike();
-        bike->field_7BC = 0;
+        bike->m_fFireBlowUpTimer = 0.0f;
         bike->Fix();
     } else if (vehicle->IsAutomobile()) {
         vehicle->m_apCollidedEntities[5] = nullptr; // todo: magic number

--- a/source/game_sa/Entity/Object/Object.cpp
+++ b/source/game_sa/Entity/Object/Object.cpp
@@ -1098,7 +1098,7 @@ void CObject::ObjectDamage(float damage, CVector* fxOrigin, CVector* fxDirection
     m_fHealth -= damage * m_pObjectInfo->m_fColDamageMultiplier;
     m_fHealth = std::max(0.0F, m_fHealth);
 
-    if (!m_nColDamageEffect || physicalFlags.bInvulnerable && damager != FindPlayerPed() && damager != FindPlayerVehicle(-1, false))
+    if (!m_nColDamageEffect || physicalFlags.bInvulnerable && damager != FindPlayerPed() && damager != FindPlayerVehicle())
         return;
 
     // Big Smoke crack palace wall break checks

--- a/source/game_sa/Entity/Ped/Ped.cpp
+++ b/source/game_sa/Entity/Ped/Ped.cpp
@@ -1343,7 +1343,7 @@ void CPed::FlagToDestroyWhenNextProcessed()
 }
 
 // 0x5E2530
-int32 CPed::ProcessEntityCollision(CPhysical* entity, CColPoint* colpoint)
+int32 CPed::ProcessEntityCollision(CEntity* entity, CColPoint* colPoint)
 {
-    return plugin::CallMethodAndReturn<int32, 0x5E2530, CPed*, CPhysical*, CColPoint*>(this, entity, colpoint);
+    return plugin::CallMethodAndReturn<int32, 0x5E2530, CPed*, CEntity*, CColPoint*>(this, entity, colPoint);
 }

--- a/source/game_sa/Entity/Ped/Ped.h
+++ b/source/game_sa/Entity/Ped/Ped.h
@@ -373,7 +373,7 @@ public:
     bool SetupLighting() override;
     void RemoveLighting(bool bRemove) override;
     void FlagToDestroyWhenNextProcessed() override;
-    int32 ProcessEntityCollision(CPhysical* entity, CColPoint* colpoint) override;
+    int32 ProcessEntityCollision(CEntity* entity, CColPoint* colPoint) override;
 
     // Process applied anim 0x86C3B4
     virtual void SetMoveAnim();

--- a/source/game_sa/Entity/Physical.h
+++ b/source/game_sa/Entity/Physical.h
@@ -63,9 +63,6 @@ enum eEntityAltCollision : uint16 {
 
 class CPhysical : public CEntity {
 public:
-    CPhysical();
-    ~CPhysical() override;
-public:
     float  field_38;
     uint32 m_nLastCollisionTime;
     union {
@@ -157,6 +154,9 @@ public:
     static CVector& fxDirection;
 
 public:
+    CPhysical();
+    ~CPhysical() override;
+
     // originally virtual functions
     void Add() override;
     void Remove() override;
@@ -165,7 +165,7 @@ public:
     void ProcessCollision() override;
     void ProcessShift() override;
     bool TestCollision(bool bApplySpeed) override;
-    virtual int32 ProcessEntityCollision(CPhysical* entity, CColPoint* colpoint);
+    virtual int32 ProcessEntityCollision(CEntity* entity, CColPoint* colPoint);
 
 public:
     void RemoveAndAdd();
@@ -244,14 +244,17 @@ private:
     friend void InjectHooksMain();
     static void InjectHooks();
 
-    void Add_Reversed();
-    void Remove_Reversed();
-    CRect* GetBoundRect_Reversed(CRect* rect);
-    void ProcessControl_Reversed();
-    void ProcessCollision_Reversed();
-    void ProcessShift_Reversed();
-    bool TestCollision_Reversed(bool bApplySpeed);
-    int32 ProcessEntityCollision_Reversed(CPhysical* entity, CColPoint* colpoint);
+    CPhysical* Constructor() { this->CPhysical::CPhysical(); return this; }
+    CPhysical* Destructor() { this->CPhysical::~CPhysical(); return this; }
+
+    void Add_Reversed() { CPhysical::Add(); }
+    void Remove_Reversed() { CPhysical::Remove(); }
+    CRect* GetBoundRect_Reversed(CRect* rect) { return CPhysical::GetBoundRect(rect); }
+    void ProcessControl_Reversed() { CPhysical::ProcessControl(); }
+    int32 ProcessEntityCollision_Reversed(CEntity* entity, CColPoint* colPoint) { return CPhysical::ProcessEntityCollision(entity, colPoint); }
+    void ProcessCollision_Reversed() { CPhysical::ProcessCollision(); }
+    void ProcessShift_Reversed() { CPhysical::ProcessShift(); }
+    bool TestCollision_Reversed(bool bApplySpeed) { return CPhysical::TestCollision(bApplySpeed); }
 };
 
 VALIDATE_SIZE(CPhysical, 0x138);

--- a/source/game_sa/Entity/Vehicle/Automobile.cpp
+++ b/source/game_sa/Entity/Vehicle/Automobile.cpp
@@ -31,7 +31,7 @@ static const CVector TIGER_GUN_POS(0.0f, 0.5f, 0.2f); // 0xC1C208
 void CAutomobile::InjectHooks()
 {
     RH_ScopedClass(CAutomobile);
-    RH_ScopedCategory("Vehicle/Ped");
+    RH_ScopedCategory("Vehicle");
 
     RH_ScopedInstall(ProcessControl_Reversed, 0x6B1880);
     RH_ScopedInstall(AddMovingCollisionSpeed_Reversed, 0x6A1ED0);

--- a/source/game_sa/Entity/Vehicle/Automobile.cpp
+++ b/source/game_sa/Entity/Vehicle/Automobile.cpp
@@ -55,23 +55,24 @@ void CAutomobile::InjectHooks()
     RH_ScopedInstall(SetHeliOrientation, 0x6A2450);
     RH_ScopedInstall(ClearHeliOrientation, 0x6A2460);
 
-    RH_ScopedInstall(GetComponentWorldPosition_Reversed, 0x6A2210); 
-    RH_ScopedInstall(IsComponentPresent_Reversed, 0x6A2250); 
-    RH_ScopedOverloadedInstall(GetDooorAngleOpenRatio_Reversed, "enum", 0x6A2270, float (CAutomobile::*)(eDoors)); 
-    RH_ScopedOverloadedInstall(GetDooorAngleOpenRatio_Reversed, "uint", 0x6A62C0, float (CAutomobile::*)(uint32)); 
-    RH_ScopedOverloadedInstall(IsDoorReady_Reversed, "enum", 0x6A2290, bool (CAutomobile::*)(eDoors)); 
-    RH_ScopedOverloadedInstall(IsDoorReady_Reversed, "uint", 0x6A6350, bool (CAutomobile::*)(uint32)); 
-    RH_ScopedOverloadedInstall(IsDoorFullyOpen_Reversed, "enum", 0x6A22D0, bool (CAutomobile::*)(eDoors)); 
-    RH_ScopedOverloadedInstall(IsDoorFullyOpen_Reversed, "uint", 0x6A63E0, bool (CAutomobile::*)(uint32)); 
-    RH_ScopedOverloadedInstall(IsDoorClosed_Reversed, "enum", 0x6A2310, bool (CAutomobile::*)(eDoors)); 
-    RH_ScopedOverloadedInstall(IsDoorClosed_Reversed, "uint", 0x6A6470, bool (CAutomobile::*)(uint32)); 
-    RH_ScopedOverloadedInstall(IsDoorMissing_Reversed, "enum", 0x6A2330, bool (CAutomobile::*)(eDoors)); 
-    RH_ScopedOverloadedInstall(IsDoorMissing_Reversed, "uint", 0x6A6500, bool (CAutomobile::*)(uint32)); 
-    RH_ScopedInstall(IsOpenTopCar_Reversed, 0x6A2350); 
-    RH_ScopedInstall(IsRoomForPedToLeaveCar_Reversed, 0x6A3850); 
-    RH_ScopedInstall(SetupDamageAfterLoad_Reversed, 0x6B3E90); 
-    RH_ScopedInstall(GetHeightAboveRoad_Reversed, 0x6A62B0); 
-    RH_ScopedInstall(GetNumContactWheels_Reversed, 0x6A62A0); 
+    RH_ScopedInstall(GetComponentWorldPosition_Reversed, 0x6A2210);
+    RH_ScopedInstall(IsComponentPresent_Reversed, 0x6A2250);
+    RH_ScopedOverloadedInstall(GetDooorAngleOpenRatio_Reversed, "enum", 0x6A2270, float (CAutomobile::*)(eDoors));
+    RH_ScopedOverloadedInstall(GetDooorAngleOpenRatio_Reversed, "uint", 0x6A62C0, float (CAutomobile::*)(uint32));
+    RH_ScopedOverloadedInstall(IsDoorReady_Reversed, "enum", 0x6A2290, bool (CAutomobile::*)(eDoors));
+    RH_ScopedOverloadedInstall(IsDoorReady_Reversed, "uint", 0x6A6350, bool (CAutomobile::*)(uint32));
+    RH_ScopedOverloadedInstall(IsDoorFullyOpen_Reversed, "enum", 0x6A22D0, bool (CAutomobile::*)(eDoors));
+    RH_ScopedOverloadedInstall(IsDoorFullyOpen_Reversed, "uint", 0x6A63E0, bool (CAutomobile::*)(uint32));
+    RH_ScopedOverloadedInstall(IsDoorClosed_Reversed, "enum", 0x6A2310, bool (CAutomobile::*)(eDoors));
+    RH_ScopedOverloadedInstall(IsDoorClosed_Reversed, "uint", 0x6A6470, bool (CAutomobile::*)(uint32));
+    RH_ScopedOverloadedInstall(IsDoorMissing_Reversed, "enum", 0x6A2330, bool (CAutomobile::*)(eDoors));
+    RH_ScopedOverloadedInstall(IsDoorMissing_Reversed, "uint", 0x6A6500, bool (CAutomobile::*)(uint32));
+    RH_ScopedInstall(IsOpenTopCar_Reversed, 0x6A2350);
+    RH_ScopedInstall(IsRoomForPedToLeaveCar_Reversed, 0x6A3850);
+    RH_ScopedInstall(SetupDamageAfterLoad_Reversed, 0x6B3E90);
+    RH_ScopedInstall(GetHeightAboveRoad_Reversed, 0x6A62B0);
+    RH_ScopedInstall(GetNumContactWheels_Reversed, 0x6A62A0);
+    RH_ScopedInstall(Teleport_Reversed, 0x6A9CA0);
     // Install("CAutomobile", "GetTowHitchPos, 0x6AF1D0, &CAutomobile::GetTowHitchPos);
     RH_ScopedInstall(Save_Reversed, 0x5D47E0);
     RH_ScopedInstall(Load_Reversed, 0x5D2980);
@@ -1700,7 +1701,7 @@ bool CAutomobile::BreakTowLink()
 // 0x6A6090
 float CAutomobile::FindWheelWidth(bool bRear)
 {
-    return plugin::CallMethodAndReturn<float, 0x6A6090, CAutomobile*>(this);
+    return plugin::CallMethodAndReturn<float, 0x6A6090, CAutomobile*, bool>(this, bRear);
 }
 
 // 0x5D47E0
@@ -3462,9 +3463,24 @@ bool CAutomobile::HasCarStoppedBecauseOfLight()
     return ((bool(__thiscall*)(CAutomobile*))0x44D520)(this);
 }
 
+// 0x6AAB50
 void CAutomobile::PreRender()
 {
     plugin::CallMethod<0x6AAB50, CAutomobile*>(this);
+}
+
+// 0x6A9CA0
+void CAutomobile::Teleport(CVector destination, bool resetRotation) {
+    CWorld::Remove(this);
+    GetPosition() = destination;
+
+    if (resetRotation)
+        SetOrientation(0.0f, 0.0f, 0.0f);
+
+    ResetMoveSpeed();
+    ResetTurnSpeed();
+    ResetSuspension();
+    CWorld::Add(this);
 }
 
 // 0x6A0750

--- a/source/game_sa/Entity/Vehicle/Automobile.h
+++ b/source/game_sa/Entity/Vehicle/Automobile.h
@@ -129,6 +129,9 @@ public:
     CAutomobile(int32 modelIndex, eVehicleCreatedBy createdBy, bool setupSuspensionLines);
     ~CAutomobile() override;
 
+    // CEntity
+    void Teleport(CVector destination, bool resetRotation) override;
+
     // CPhysical
     void ProcessControl() override;
 
@@ -371,7 +374,7 @@ private:
     void DoHoverSuspensionRatios_Reversed() { return CAutomobile::DoHoverSuspensionRatios(); }
     void ProcessSuspension_Reversed() { return CAutomobile::ProcessSuspension(); }
 
-    // CPhysical
+    void Teleport_Reversed(CVector destination, bool resetRotation) { CAutomobile::Teleport(destination, resetRotation); };
     void ProcessControl_Reversed() { CAutomobile::ProcessControl(); }
 
     // CVehicle

--- a/source/game_sa/Entity/Vehicle/Automobile.h
+++ b/source/game_sa/Entity/Vehicle/Automobile.h
@@ -16,7 +16,7 @@
 #include "eCarWheel.h"
 #include "eCarNodes.h"
 
-enum eWheelStatus;
+class CVehicleModelInfo;
 
 using eWheels = eCarWheel; // todo: maybe wrong, "eWheels" is original enum.
 
@@ -38,13 +38,14 @@ public:
     RwFrame*       m_aCarNodes[CAR_NUM_NODES];
     CBouncingPanel m_panels[3];
     CDoor          m_swingingChassis;
-    CColPoint      m_wheelColPoint[4];
-    float          m_fWheelsSuspensionCompression[4]; // [0-1] with 0 being suspension fully compressed, and 1 being completely relaxed
-    float          m_fWheelsSuspensionCompressionPrev[4];
+
+    CColPoint      m_aWheelColPoint[4];
+    float          m_fWheelsSuspensionCompression[4];     // 0x7D4 - [0-1] with 0 being suspension fully compressed, and 1 being completely relaxed
+    float          m_fWheelsSuspensionCompressionPrev[4]; // 0x7E4
     float          m_aWheelTimer[4];
     float          field_804;
-    float          m_intertiaValue1;
-    float          m_intertiaValue2;
+    float          m_intertiaValue1; // m_anWheelSurfaceType[2]
+    float          m_intertiaValue2; // *
     int32          m_wheelSkidmarkType[4];
     bool           m_wheelSkidmarkBloodState[4];
     bool           m_wheelSkidmarkMuddy[4];
@@ -84,43 +85,18 @@ public:
     float       m_fFrontHeightAboveRoad;
     float       m_fRearHeightAboveRoad;
     float       m_fCarTraction;
+
     float       m_fTireTemperature;
     float       m_aircraftGoToHeading;
-    float       m_fRotationBalance; // used in CHeli::TestSniperCollision
+    float       m_fRotationBalance; // Controls destroyed helicopter rotation
     float       m_fMoveDirection;
     int32       field_8B4[6];
     int32       field_8C8[6];
     int32       m_dwBurnTimer;
-    CPhysical*  m_pWheelCollisionEntity[4];
-    CVector     m_vWheelCollisionPos[4];
-    char        field_924;
-    char        field_925;
-    char        field_926;
-    char        field_927;
-    char        field_928;
-    char        field_929;
-    char        field_92A;
-    char        field_92B;
-    char        field_92C;
-    char        field_92D;
-    char        field_92E;
-    char        field_92F;
-    char        field_930;
-    char        field_931;
-    char        field_932;
-    char        field_933;
-    char        field_934;
-    char        field_935;
-    char        field_936;
-    char        field_937;
-    char        field_938;
-    char        field_939;
-    char        field_93A;
-    char        field_93B;
-    char        field_93C;
-    char        field_93D;
-    char        field_93E;
-    char        field_93F;
+    CPhysical*  m_apWheelCollisionEntity[4];
+    CVector     m_vWheelCollisionPos[4]; // Bike::m_avTouchPointsLocalSpace
+
+    char        field_928[28];
     int32       field_940;
     int32       field_944;
     float       m_fDoomVerticalRotation;
@@ -149,8 +125,9 @@ public:
     static CMatrix*        matW2B;
 
 public:
-    CAutomobile(plugin::dummy_func_t) : CVehicle(plugin::dummy) {}
+    CAutomobile(plugin::dummy_func_t) : CVehicle(plugin::dummy) { /* todo: remove NOTSA*/ }
     CAutomobile(int32 modelIndex, eVehicleCreatedBy createdBy, bool setupSuspensionLines);
+    ~CAutomobile() override;
 
     // CPhysical
     void ProcessControl() override;
@@ -201,91 +178,7 @@ public:
     virtual void DoHoverSuspensionRatios();
     virtual void ProcessSuspension();
 
-    void PreRender() override { plugin::CallMethod<0x6AAB50, CAutomobile*>(this); }
-
-    void SetEngineState(bool state)
-    {
-        if (vehicleFlags.bEngineBroken)
-            vehicleFlags.bEngineOn = false;
-        else
-            vehicleFlags.bEngineOn = state;
-    }
-
-    bool IsAnyWheelMakingContactWithGround() {
-        return m_fWheelsSuspensionCompression[0] != 1.0F
-            || m_fWheelsSuspensionCompression[1] != 1.0F
-            || m_fWheelsSuspensionCompression[2] != 1.0F
-            || m_fWheelsSuspensionCompression[3] != 1.0F;
-    };
-
-    bool IsAnyWheelNotMakingContactWithGround() {
-        return m_fWheelsSuspensionCompression[0] == 1.0F
-            || m_fWheelsSuspensionCompression[1] == 1.0F
-            || m_fWheelsSuspensionCompression[2] == 1.0F
-            || m_fWheelsSuspensionCompression[3] == 1.0F;
-    };
-
-    bool IsAnyWheelTouchingSand() {
-        for (int32 i = 0; i < 4; i++) {
-            if (m_fWheelsSuspensionCompression[i] < 1.0f) {
-                if (g_surfaceInfos->GetAdhesionGroup(m_wheelColPoint[i].m_nSurfaceTypeB) == ADHESION_GROUP_SAND)
-                    return true;
-            }
-        }
-        return false;
-    }
-
-    bool IsAnyWheelTouchingRailTrack() {
-        for (int32 i = 0; i < 4; i++) {
-            if (m_fWheelsSuspensionCompression[i] < 1.0f) {
-                if (m_wheelColPoint[i].m_nSurfaceTypeB == SURFACE_RAILTRACK)
-                    return true;
-            }
-        }
-        return false;
-    }
-
-    bool IsAnyWheelTouchingShallowWaterGround() {
-        for (int32 i = 0; i < 4; i++) {
-            if (m_fWheelsSuspensionCompression[i] < 1.0f && m_wheelColPoint[i].m_nSurfaceTypeB == SURFACE_WATER_SHALLOW)
-                return true;
-        }
-        return false;
-    }
-
-    bool IsAnyFrontAndRearWheelTouchingGround() {
-        if (m_fWheelsSuspensionCompression[CARWHEEL_FRONT_LEFT] < 1.0f  || m_fWheelsSuspensionCompression[CARWHEEL_FRONT_RIGHT] < 1.0f) {
-            if (m_fWheelsSuspensionCompression[CARWHEEL_REAR_LEFT] < 1.0f || m_fWheelsSuspensionCompression[CARWHEEL_REAR_RIGHT] < 1.0f)
-                return true;
-        }
-        return false;
-    }
-
-    [[nodiscard]] bool AreFrontWheelsNotTouchingGround() const { // NOTSA
-        return m_fWheelsSuspensionCompression[eCarWheel::CARWHEEL_FRONT_LEFT] >= 1.0f && m_fWheelsSuspensionCompression[eCarWheel::CARWHEEL_FRONT_RIGHT];
-    }
-
-    [[nodiscard]] bool AreRearWheelsNotTouchingGround() const { // NOTSA
-        return m_fWheelsSuspensionCompression[eCarWheel::CARWHEEL_REAR_LEFT] >= 1.0f && m_fWheelsSuspensionCompression[eCarWheel::CARWHEEL_REAR_RIGHT];
-    }
-
-    // check the previous compression state using m_fWheelsSuspensionCompressionPrev
-    bool DidAnyWheelTouchShallowWaterGroundPrev() {
-        for (int32 i = 0; i < 4; i++) {
-            if (m_fWheelsSuspensionCompressionPrev[i] < 1.0f && m_wheelColPoint[i].m_nSurfaceTypeB == SURFACE_WATER_SHALLOW)
-                return true;
-        }
-        return false;
-    }
-    bool DidAnyWheelTouchGroundPrev() {
-        for (int32 i = 0; i < 4; i++) {
-            if (m_fWheelsSuspensionCompressionPrev[i] < 1.0f)
-                return true;
-        }
-        return false;
-    }
-
-    bool IsRealHeli() { return !!(m_pHandlingData->m_nModelFlags & VEHICLE_HANDLING_MODEL_IS_HELI); }
+    void PreRender() override;
 
     // Find and save components ptrs (RwFrame) to m_modelNodes array
     void SetupModelNodes();
@@ -342,8 +235,7 @@ public:
     void StopNitroEffect();
     void NitrousControl(int8);
     void TowTruckControl();
-    // Empty function
-    CPed* KnockPedOutCar(eWeaponType arg0, uint16 arg1, CPed* arg2);
+    CPed* KnockPedOutCar(eWeaponType type, uint16 a2, CPed* ped);
     void PopBootUsingPhysics();
     // Close all doors
     void CloseAllDoors();
@@ -381,7 +273,93 @@ public:
     bool RcbanditCheckHitWheels();
     void FireTruckControl(CFire* fire);
     bool HasCarStoppedBecauseOfLight();
+
+    // NOTSA section
+
     CDoor& GetDoor(eDoors door) { return m_doors[(unsigned)door]; }
+
+    void SetEngineState(bool state) {
+        if (vehicleFlags.bEngineBroken)
+            vehicleFlags.bEngineOn = false;
+        else
+            vehicleFlags.bEngineOn = state;
+    }
+
+    bool IsAnyWheelMakingContactWithGround() {
+        return m_fWheelsSuspensionCompression[0] != 1.0F
+               || m_fWheelsSuspensionCompression[1] != 1.0F
+               || m_fWheelsSuspensionCompression[2] != 1.0F
+               || m_fWheelsSuspensionCompression[3] != 1.0F;
+    };
+
+    bool IsAnyWheelNotMakingContactWithGround() {
+        return m_fWheelsSuspensionCompression[0] == 1.0F
+               || m_fWheelsSuspensionCompression[1] == 1.0F
+               || m_fWheelsSuspensionCompression[2] == 1.0F
+               || m_fWheelsSuspensionCompression[3] == 1.0F;
+    };
+
+    bool IsAnyWheelTouchingSand() {
+        for (int32 i = 0; i < 4; i++) {
+            if (m_fWheelsSuspensionCompression[i] < 1.0f) {
+                if (g_surfaceInfos->GetAdhesionGroup(m_aWheelColPoint[i].m_nSurfaceTypeB) == ADHESION_GROUP_SAND)
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    bool IsAnyWheelTouchingRailTrack() {
+        for (int32 i = 0; i < 4; i++) {
+            if (m_fWheelsSuspensionCompression[i] < 1.0f) {
+                if (m_aWheelColPoint[i].m_nSurfaceTypeB == SURFACE_RAILTRACK)
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    bool IsAnyWheelTouchingShallowWaterGround() {
+        for (int32 i = 0; i < 4; i++) {
+            if (m_fWheelsSuspensionCompression[i] < 1.0f && m_aWheelColPoint[i].m_nSurfaceTypeB == SURFACE_WATER_SHALLOW)
+                return true;
+        }
+        return false;
+    }
+
+    bool IsAnyFrontAndRearWheelTouchingGround() {
+        if (m_fWheelsSuspensionCompression[CARWHEEL_FRONT_LEFT] < 1.0f  || m_fWheelsSuspensionCompression[CARWHEEL_FRONT_RIGHT] < 1.0f) {
+            if (m_fWheelsSuspensionCompression[CARWHEEL_REAR_LEFT] < 1.0f || m_fWheelsSuspensionCompression[CARWHEEL_REAR_RIGHT] < 1.0f)
+                return true;
+        }
+        return false;
+    }
+
+    [[nodiscard]] bool AreFrontWheelsNotTouchingGround() const {
+        return m_fWheelsSuspensionCompression[CARWHEEL_FRONT_LEFT] >= 1.0f && m_fWheelsSuspensionCompression[CARWHEEL_FRONT_RIGHT];
+    }
+
+    [[nodiscard]] bool AreRearWheelsNotTouchingGround() const {
+        return m_fWheelsSuspensionCompression[CARWHEEL_REAR_LEFT] >= 1.0f && m_fWheelsSuspensionCompression[CARWHEEL_REAR_RIGHT];
+    }
+
+    // check the previous compression state using m_fWheelsSuspensionCompressionPrev
+    bool DidAnyWheelTouchShallowWaterGroundPrev() {
+        for (int32 i = 0; i < 4; i++) {
+            if (m_fWheelsSuspensionCompressionPrev[i] < 1.0f && m_aWheelColPoint[i].m_nSurfaceTypeB == SURFACE_WATER_SHALLOW)
+                return true;
+        }
+        return false;
+    }
+    bool DidAnyWheelTouchGroundPrev() {
+        for (float prevSuspension : m_fWheelsSuspensionCompressionPrev) {
+            if (prevSuspension < 1.0f)
+                return true;
+        }
+        return false;
+    }
+
+    bool IsRealHeli() { return !!(m_pHandlingData->m_nModelFlags & VEHICLE_HANDLING_MODEL_IS_HELI); }
 
 private:
     friend void InjectHooksMain();

--- a/source/game_sa/Entity/Vehicle/Bike.cpp
+++ b/source/game_sa/Entity/Vehicle/Bike.cpp
@@ -10,12 +10,50 @@
 
 #include "Buoyancy.h"
 
-void CBike::InjectHooks()
-{
+void CBike::InjectHooks() {
     RH_ScopedClass(CBike);
     RH_ScopedCategory("Vehicle/Ped");
 
+    // RH_ScopedInstall(Constructor, 0x6BF430);
+    RH_ScopedInstall(Destructor, 0x6B57A0);
+    RH_ScopedInstall(dmgDrawCarCollidingParticles, 0x6B5A00);
+    // RH_ScopedInstall(DamageKnockOffRider, 0x6B5A10);
+    RH_ScopedInstall(KnockOffRider, 0x6B5F40);
+    // RH_ScopedInstall(SetRemoveAnimFlags, 0x6B5F50);
+    RH_ScopedInstall(ReduceHornCounter, 0x6B5F90);
+    // RH_ScopedInstall(ProcessAI, 0x6BC930);
     RH_ScopedInstall(ProcessBuoyancy, 0x6B5FB0);
+    // RH_ScopedInstall(ResetSuspension, 0x6B6740);
+    RH_ScopedInstall(GetAllWheelsOffGround, 0x6B6790);
+    RH_ScopedInstall(DebugCode, 0x6B67A0);
+    // RH_ScopedInstall(DoSoftGroundResistance, 0x6B6D40);
+    RH_ScopedInstall(PlayHornIfNecessary, 0x6B7130);
+    // RH_ScopedInstall(CalculateLeanMatrix, 0x6B7150);
+    // RH_ScopedInstall(ProcessRiderAnims, 0x6B7280);
+    // RH_ScopedInstall(FixHandsToBars, 0x6B7F90);
+    // RH_ScopedInstall(PlaceOnRoadProperly, 0x6BEEB0);
+    // RH_ScopedInstall(GetCorrectedWorldDoorPosition, 0x6BF230);
+    RH_ScopedInstall(Fix_Reversed, 0x6B7050);
+    // RH_ScopedInstall(BlowUpCar_Reversed, 0x6BEA10);
+    RH_ScopedInstall(ProcessDrivingAnims_Reversed, 0x6BF400);
+    // RH_ScopedInstall(BurstTyre_Reversed, 0x6BEB20);
+    // RH_ScopedInstall(ProcessControlInputs_Reversed, 0x6BE310);
+    // RH_ScopedInstall(ProcessEntityCollision_Reversed, 0x6BDEA0);
+    RH_ScopedInstall(Render_Reversed, 0x6BDE20);
+    // RH_ScopedInstall(PreRender_Reversed, 0x6BD090);
+    RH_ScopedInstall(Teleport_Reversed, 0x6BCFC0);
+    // RH_ScopedInstall(ProcessControl_Reversed, 0x6B9250);
+    // RH_ScopedInstall(VehicleDamage_Reversed, 0x6B8EC0);
+    // RH_ScopedInstall(SetupSuspensionLines_Reversed, 0x6B89B0);
+    RH_ScopedInstall(SetModelIndex_Reversed, 0x6B8970);
+    // RH_ScopedInstall(PlayCarHorn_Reversed, 0x6B7080);
+    RH_ScopedInstall(SetupDamageAfterLoad_Reversed, 0x6B7070);
+    // RH_ScopedInstall(DoBurstAndSoftGroundRatios_Reversed, 0x6B6950);
+    // RH_ScopedInstall(SetUpWheelColModel_Reversed, 0x6B67E0);
+    RH_ScopedInstall(RemoveRefsToVehicle_Reversed, 0x6B67B0);
+    // RH_ScopedInstall(ProcessControlCollisionCheck_Reversed, 0x6B6620);
+    RH_ScopedInstall(GetComponentWorldPosition_Reversed, 0x6B5990);
+    RH_ScopedInstall(ProcessOpenDoor_Reversed, 0x6B58D0);
 }
 
 // 0x6BF430
@@ -23,14 +61,9 @@ CBike::CBike(int32 modelIndex, eVehicleCreatedBy createdBy) : CVehicle(plugin::d
     plugin::CallMethod<0x6BF430, CBike*, int32, eVehicleCreatedBy>(this, modelIndex, createdBy);
 }
 
-// 0x0
-void CBike::ProcessAI(uint32& arg0) {
-    ((void(__thiscall*)(CBike*, uint32&))(*(void***)this)[66])(this, arg0);
-}
-
-// 0x6B5960
-void CBike::SetupModelNodes() {
-    ((void(__thiscall*)(CBike*))0x6B5960)(this);
+// 0x6B57A0
+CBike::~CBike() {
+    m_vehicleAudio.Terminate();
 }
 
 // 0x6B5A00
@@ -45,8 +78,8 @@ bool CBike::DamageKnockOffRider(CVehicle* arg0, float arg1, uint16 arg2, CEntity
 
 // dummy function
 // 0x6B5F40
-CPed* CBike::KnockOffRider(eWeaponType arg0, uint8 arg1, CPed* arg2, bool arg3) {
-    return arg2;
+CPed* CBike::KnockOffRider(eWeaponType arg0, uint8 arg1, CPed* ped, bool arg3) {
+    return ped;
 }
 
 // 0x6B5F50
@@ -56,7 +89,8 @@ void CBike::SetRemoveAnimFlags(CPed* ped) {
 
 // 0x6B5F90
 void CBike::ReduceHornCounter() {
-    ((void(__thiscall*)(CBike*))0x6B5F90)(this);
+    if (m_nHornCounter)
+        m_nHornCounter -= 1;
 }
 
 // 0x6B5FB0
@@ -126,7 +160,7 @@ inline void CBike::ProcessPedInVehicleBuoyancy(CPed* ped, bool bIsDriver)
         return;
 
     if (ped->IsPlayer())
-        static_cast<CPlayerPed*>(ped)->HandlePlayerBreath(true, 1.0F);
+        ped->AsPlayer()->HandlePlayerBreath(true, 1.0F);
 
     if (IsAnyWheelMakingContactWithGround()) {
         if (!ped->IsPlayer()) {
@@ -161,14 +195,52 @@ inline void CBike::ProcessPedInVehicleBuoyancy(CPed* ped, bool bIsDriver)
     }
 }
 
+// 0x6BC930
+bool CBike::ProcessAI(uint32& extraHandlingFlags) {
+    return plugin::CallMethodAndReturn<bool, 0x6BC930, CBike*, uint32&>(this, extraHandlingFlags);
+}
+
+// 0x6BF400
+void CBike::ProcessDrivingAnims(CPed* driver, uint8 bBlend) {
+    if (m_bOffscreen && m_nStatus == STATUS_PLAYER)
+        return;
+
+    ProcessRiderAnims(driver, this, &m_rideAnimData, m_pBikeHandlingData, 0);
+}
+
+// 0x6B7280
+void CBike::ProcessRiderAnims(CPed* rider, CVehicle* vehicle, CRideAnimData* rideData, tBikeHandlingData* handling, int16 a5) {
+    plugin::Call<0x6B7280, CPed*, CVehicle*, CRideAnimData*, tBikeHandlingData*, int16>(rider, vehicle, rideData, handling, a5);
+}
+
+// 0x6BEB20
+bool CBike::BurstTyre(uint8 tyreComponentId, bool bPhysicalEffect) {
+    return plugin::CallMethodAndReturn<bool, 0x6BEB20, CBike*, uint8, bool>(this, tyreComponentId, bPhysicalEffect);
+}
+
+// 0x6BE310
+void CBike::ProcessControlInputs(uint8 playerNum) {
+    plugin::CallMethod<0x6BE310, CBike*, uint8>(this, playerNum);
+}
+
+// 0x6BDEA0
+int32 CBike::ProcessEntityCollision(CEntity* entity, CColPoint* colPoint) {
+    return plugin::CallMethodAndReturn<int32, 0x6BDEA0, CBike*, CEntity*, CColPoint*>(this, entity, colPoint);
+}
+
+// 0x6B9250
+void CBike::ProcessControl() {
+    plugin::CallMethod<0x6B9250, CBike*>(this);
+}
+
 // 0x6B6740
 void CBike::ResetSuspension() {
     ((void(__thiscall*)(CBike*))0x6B6740)(this);
 }
 
 // 0x6B6790
-bool CBike::GetAllWheelsOffGround() {
-    return ((bool(__thiscall*)(CBike*))0x6B6790)(this);
+bool CBike::GetAllWheelsOffGround() const {
+    return m_nNumWheelsOnGround == 0;
 }
 
 // 0x6B67A0
@@ -183,17 +255,25 @@ void CBike::DoSoftGroundResistance(uint32& arg0) {
 
 // 0x6B7130
 void CBike::PlayHornIfNecessary() {
-    ((void(__thiscall*)(CBike*))0x6B7130)(this);
+    if (m_autoPilot.carCtrlFlags.bHonkAtCar || m_autoPilot.carCtrlFlags.bHonkAtPed)
+        PlayCarHorn();
 }
 
 // 0x6B7150
 void CBike::CalculateLeanMatrix() {
-    ((void(__thiscall*)(CBike*))0x6B7150)(this);
-}
+    return ((void(__thiscall*)(CBike*))0x6B7150)(this);
 
-// 0x6B7280
-void CBike::ProcessRiderAnims(CPed* rider, CVehicle* vehicle, CRideAnimData* rideData, tBikeHandlingData* handling) {
-    ((void(__cdecl*)(CPed*, CVehicle*, CRideAnimData*, tBikeHandlingData*))0x6B7280)(rider, vehicle, rideData, handling);
+    // wrong
+    if (!m_bLeanMatrixCalculated) {
+        CMatrix m;
+        m.SetRotateX(fabs(m_rideAnimData.m_fAnimLean) * -0.05f);
+        m.RotateY(m_rideAnimData.m_fAnimLean);
+        m_mLeanMatrix = *static_cast<CMatrix*>(m_matrix);
+        m_mLeanMatrix *= m;
+
+        m_bLeanMatrixCalculated = true;
+        m_mLeanMatrix.GetPosition() = CEntity::GetColModel()->GetBoundingBox().m_vecMin.z * m_matrix->GetUp() * (1.0f - cos(m_rideAnimData.m_fAnimLean));
+    }
 }
 
 // 0x6B7F90
@@ -213,18 +293,118 @@ void CBike::GetCorrectedWorldDoorPosition(CVector& out, CVector arg1, CVector ar
 
 // 0x6BEA10
 void CBike::BlowUpCar(CEntity* damager, uint8 bHideExplosion) {
-    return BlowUpCar_Reversed(damager, bHideExplosion);
-}
-
-void CBike::BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion) {
     plugin::CallMethod<0x6BEA10, CBike*, CEntity*, uint8>(this, damager, bHideExplosion);
 }
 
 // 0x6B7050
 void CBike::Fix() {
-    Fix_Reversed();
+    vehicleFlags.bIsDamaged = false;
+    damageFlags.bDamageFlag7 = false;
+    m_anWheelDamageState[0] = 0;
+    m_anWheelDamageState[1] = 0;
 }
 
-void CBike::Fix_Reversed() {
-    plugin::CallMethod<0x6B7050, CBike*>(this);
+// 0x6BD090
+void CBike::PreRender() {
+    plugin::CallMethod<0x6BD090, CBike*>(this);
+}
+
+// 0x6BDE20
+void CBike::Render() {
+    auto savedRef = 0;
+    RwRenderStateGet(rwRENDERSTATEALPHATESTFUNCTIONREF, &savedRef);
+    RwRenderStateSet(rwRENDERSTATEALPHATESTFUNCTIONREF, RWRSTATE(1));
+
+    m_nTimeTillWeNeedThisCar = CTimer::GetTimeInMS() + 3000;
+    CVehicle::Render();
+
+    if (m_renderLights.m_bRightFront) {
+        CalculateLeanMatrix();
+        CVehicle::DoHeadLightBeam(0, m_mLeanMatrix, true);
+    }
+
+    RwRenderStateSet(rwRENDERSTATEALPHATESTFUNCTIONREF, RWRSTATE(savedRef));
+}
+
+// 0x6BCFC0
+void CBike::Teleport(CVector destination, bool resetRotation) {
+    CWorld::Remove(this);
+
+    GetPosition() = destination;
+    if (resetRotation)
+        SetOrientation(0.0f, 0.0f, 0.0f);
+
+    ResetMoveSpeed();
+    ResetTurnSpeed();
+    ResetSuspension();
+
+    CWorld::Add(this);
+}
+
+// 0x6B8EC0
+void CBike::VehicleDamage(float damageIntensity, uint16 collisionComponent, CEntity* damager, CVector* vecCollisionCoors, CVector* vecCollisionDirection, eWeaponType weapon) {
+    plugin::CallMethod<0x6B8EC0, CBike*, float, uint16, CEntity*, CVector*, CVector*, eWeaponType>(this, damageIntensity, collisionComponent, damager, vecCollisionCoors, vecCollisionDirection, weapon);
+}
+
+// 0x6B89B0
+void CBike::SetupSuspensionLines() {
+    plugin::CallMethod<0x6B89B0, CBike*>(this);
+}
+
+// 0x6B8970
+void CBike::SetModelIndex(uint32 index) {
+    CVehicle::SetModelIndex(index);
+    SetupModelNodes();
+}
+
+// 0x6B5960
+void CBike::SetupModelNodes() {
+    std::ranges::fill(m_aBikeNodes, nullptr);
+    CClumpModelInfo::FillFrameArray(m_pRwClump, m_aBikeNodes);
+}
+
+// 0x6B7080
+void CBike::PlayCarHorn() {
+    plugin::CallMethod<0x6B7080, CBike*>(this);
+}
+
+// 0x6B7070
+void CBike::SetupDamageAfterLoad() {
+    // NOP
+}
+
+// 0x6B6950
+void CBike::DoBurstAndSoftGroundRatios() {
+    plugin::CallMethod<0x6B6950, CBike*>(this);
+}
+
+// 0x6B67E0
+bool CBike::SetUpWheelColModel(CColModel* wheelCol) {
+    return plugin::CallMethodAndReturn<bool, 0x6B67E0, CBike*, CColModel*>(this, wheelCol);
+}
+
+// 0x6B67B0
+void CBike::RemoveRefsToVehicle(CEntity* entityToRemove) {
+    for (auto& entity: m_apWheelCollisionEntity) {
+        if (entity == entityToRemove)
+            entity = nullptr;
+    }
+}
+
+// 0x6B6620
+void CBike::ProcessControlCollisionCheck(bool applySpeed) {
+    plugin::CallMethod<0x6B6620, CBike*, bool>(this, applySpeed);
+}
+
+// 0x6B5990
+void CBike::GetComponentWorldPosition(int32 componentId, CVector& outPos) {
+    if (IsComponentPresent(componentId))
+        outPos = RwFrameGetLTM(m_aBikeNodes[componentId])->pos;
+    else
+        printf("BikeNode missing: %d %d\n", m_nModelIndex, componentId);
+}
+
+// 0x6B58D0
+void CBike::ProcessOpenDoor(CPed* ped, uint32 doorComponentId, uint32 animGroup, uint32 animId, float fTime) {
+    // NOP
 }

--- a/source/game_sa/Entity/Vehicle/Bike.cpp
+++ b/source/game_sa/Entity/Vehicle/Bike.cpp
@@ -12,7 +12,7 @@
 
 void CBike::InjectHooks() {
     RH_ScopedClass(CBike);
-    RH_ScopedCategory("Vehicle/Ped");
+    RH_ScopedCategory("Vehicle");
 
     // RH_ScopedInstall(Constructor, 0x6BF430);
     RH_ScopedInstall(Destructor, 0x6B57A0);

--- a/source/game_sa/Entity/Vehicle/Bike.h
+++ b/source/game_sa/Entity/Vehicle/Bike.h
@@ -32,70 +32,67 @@ public:
     CMatrix  m_mLeanMatrix;
     union {
         struct {
-            uint8 bDamageFlag1 : 1;
-            uint8 bDamageFlag2 : 1;
-            uint8 bIgnoreWater : 1;
-            uint8 bDamageFlag3 : 1;
-            uint8 bDamageFlag4 : 1;
-            uint8 bDamageFlag5 : 1;
-            uint8 bDamageFlag7 : 1;
-            uint8 bDamageFlag8 : 1;
-        } damageFlags;
-        uint8 ucDamageFlags;
+            uint8 bDamageFlag1     : 1;
+            uint8 bDamageFlag2     : 1;
+            uint8 bIgnoreWater     : 1; // bWaterTight
+            uint8 bIsBeingPickedUp : 1;
+            uint8 bIsStanding      : 1;
+            uint8 bExtraSpeed      : 1;
+            uint8 bIsOnFire        : 1;
+            uint8 bWheelieCam      : 1;
+        } bikeFlags;
+        uint8 nBikeFlags;
     };
-    char               field_615[27];
-    CVector            field_630;
+    CVector            f618;
+    CVector            m_vecAvgSurfaceNormal; // sued
+    CVector            m_vecAvgSurfaceRight;  // sued
     tBikeHandlingData* m_pBikeHandlingData;
     CRideAnimData      m_rideAnimData;
     uint8              m_anWheelDamageState[2];
-    char               field_65E;
-    char               field_65F;
 
     CColPoint     m_aWheelColPoint[4];
     float         m_fWheelsSuspensionCompression[4];
     float         m_fWheelsSuspensionCompressionPrev[4];
     float         m_aWheelTimer[4];
-    float         field_740;
+    float         field_740; // sued unused
     int32         m_anWheelSurfaceType[2];
     bool          m_abBloodState[2];
-    bool          field_74E[2];
+    bool          m_aWheelSkidmarkUnk[2]; // sued
     float         m_afWheelRotationX[2];
     float         m_fWheelSpeed[2];
 
-    // CBmx::GetFrameOffset
-    float         field_760;
-    float         field_764;
-    float         field_768;
-    float         field_76C;
-    // end
+    float         m_aWheelFrontPosition;     // sued m_aWheelPosition[2]
+    float         m_aWheelRearPosition;
+    float         m_aWheelBaseFrontPosition; // sued m_aWheelBasePosition[2]
+    float         m_aWheelBaseRearPosition;
 
-    float         field_770[4];
-    float         field_780[4];
+    float         field_770[4]; // sued m_aSuspensionSpringLength[4]
+    float         field_780[4]; // sued m_aSuspensionLineLength[4]
     float         m_fHeightAboveRoad;
-    float         m_fCarTraction;
+    float         m_fTraction;
 
-    float         field_798;
-    float         field_79C;
-    float         field_7A0;
-    float         field_7A4;
-    int16         field_7A8;
-    char          field_7AA[2];
-    int32         field_7AC;
-    int32         field_7B0;
+    float         m_fRearForkLength;
+    float         m_fFrontForkY;
+    float         m_fFrontForkZ;
+    float         m_fFrontForkSlope;
+
+    int16         m_bDoingBurnout;
+    float         m_fTireTemperature;
+    float         m_fBrakeDestabilization;
     bool          m_bPedLeftHandFixed;
     bool          m_bPedRightHandFixed;
     char          field_7B6[2];
-    int32         field_7B8;
-    int32         field_7BC;
-    CEntity*      m_apWheelCollisionEntity[4];
-    CVector       m_avTouchPointsLocalSpace[4];
+    int32         field_7B8; // sued float m_fVelocityChangeForAudio
+    float         m_fFireBlowUpTimer;
+    CEntity*      m_apWheelCollisionEntity[4];  // sued m_aGroundPhysical
+    CVector       m_avTouchPointsLocalSpace[4]; // sued m_aGroundOffset
     CEntity*      m_pDamager;
     uint8         m_nNumContactWheels;
     uint8         m_nNumWheelsOnGround;
-    char          field_806;
-    char          field_807;
-    int32         field_808;
-    uint32        m_anWheelState[2]; // enum tWheelState
+    uint8         m_nDriveWheelsOnGround;     // sued
+    uint8         m_nDriveWheelsOnGroundPrev; // sued
+    int32         m_fGasPedalAudio;           // sued
+    tWheelState   m_anWheelState[2];
 
 public:
     CBike(plugin::dummy_func_t) : CVehicle(plugin::dummy), m_mLeanMatrix(plugin::dummy) { /* todo: remove NOTSA */ }

--- a/source/game_sa/Entity/Vehicle/Bike.h
+++ b/source/game_sa/Entity/Vehicle/Bike.h
@@ -11,26 +11,24 @@
 struct tBikeHandlingData;
 
 enum eBikeNodes {
-    BIKE_NODE_NONE = 0,
-    BIKE_CHASSIS = 1,
+    BIKE_NODE_NONE   = 0,
+    BIKE_CHASSIS     = 1,
     BIKE_FORKS_FRONT = 2,
-    BIKE_FORKS_REAR = 3,
+    BIKE_FORKS_REAR  = 3,
     BIKE_WHEEL_FRONT = 4,
-    BIKE_WHEEL_REAR = 5,
-    BIKE_MUDGUARD = 6,
-    BIKE_HANDLEBARS = 7,
-    BIKE_MISC_A = 8,
-    BIKE_MISC_B = 9,
+    BIKE_WHEEL_REAR  = 5,
+    BIKE_MUDGUARD    = 6,
+    BIKE_HANDLEBARS  = 7,
+    BIKE_MISC_A      = 8,
+    BIKE_MISC_B      = 9,
+
     BIKE_NUM_NODES
 };
 
 class CBike : public CVehicle {
-protected:
-    CBike(plugin::dummy_func_t) : CVehicle(plugin::dummy), m_mLeanMatrix(plugin::dummy) {}
 public:
     RwFrame* m_aBikeNodes[BIKE_NUM_NODES];
     bool     m_bLeanMatrixCalculated;
-    char     _pad0[3];
     CMatrix  m_mLeanMatrix;
     union {
         struct {
@@ -45,31 +43,37 @@ public:
         } damageFlags;
         uint8 ucDamageFlags;
     };
-    char          field_615[27];
-    CVector       field_630;
-    void*         m_pBikeHandlingData;
-    CRideAnimData m_rideAnimData;
-    uint8         m_anWheelDamageState[2];
-    char          field_65E;
-    char          field_65F;
-    CColPoint     m_anWheelColPoint[4];
+    char               field_615[27];
+    CVector            field_630;
+    tBikeHandlingData* m_pBikeHandlingData;
+    CRideAnimData      m_rideAnimData;
+    uint8              m_anWheelDamageState[2];
+    char               field_65E;
+    char               field_65F;
+
+    CColPoint     m_aWheelColPoint[4];
     float         m_fWheelsSuspensionCompression[4];
-    float         field_720[4];
-    float         m_wheelCollisionState[4];
+    float         m_fWheelsSuspensionCompressionPrev[4];
+    float         m_aWheelTimer[4];
     float         field_740;
     int32         m_anWheelSurfaceType[2];
-    char          field_74C[2];
-    char          field_74E[2];
+    bool          m_abBloodState[2];
+    bool          field_74E[2];
     float         m_afWheelRotationX[2];
     float         m_fWheelSpeed[2];
+
+    // CBmx::GetFrameOffset
     float         field_760;
     float         field_764;
     float         field_768;
     float         field_76C;
+    // end
+
     float         field_770[4];
     float         field_780[4];
     float         m_fHeightAboveRoad;
     float         m_fCarTraction;
+
     float         field_798;
     float         field_79C;
     float         field_7A0;
@@ -94,11 +98,31 @@ public:
     uint32        m_anWheelState[2]; // enum tWheelState
 
 public:
-    static void InjectHooks();
+    CBike(plugin::dummy_func_t) : CVehicle(plugin::dummy), m_mLeanMatrix(plugin::dummy) { /* todo: remove NOTSA */ }
+    CBike(int32 modelIndex, eVehicleCreatedBy createdBy); // 0x6BF430
+    ~CBike() override;
 
-    // VTABLE
     void Fix() override;
     void BlowUpCar(CEntity* damager, uint8 bHideExplosion) override;
+    void ProcessDrivingAnims(CPed* driver, uint8 bBlend) override;
+    bool BurstTyre(uint8 tyreComponentId, bool bPhysicalEffect) override;
+    void ProcessControlInputs(uint8 playerNum) override;
+    int32 ProcessEntityCollision(CEntity* entity, CColPoint* colPoint) override;
+    void Render() override;
+    void PreRender() override;
+    void Teleport(CVector destination, bool resetRotation) override;
+    void ProcessControl() override;
+    void VehicleDamage(float damageIntensity, uint16 collisionComponent, CEntity* damager, CVector* vecCollisionCoors, CVector* vecCollisionDirection, eWeaponType weapon) override;
+    void SetupSuspensionLines() override;
+    void SetModelIndex(uint32 index) override;
+    void PlayCarHorn() override;
+    void SetupDamageAfterLoad() override;
+    void DoBurstAndSoftGroundRatios() override;
+    bool SetUpWheelColModel(CColModel* wheelCol) override;
+    void RemoveRefsToVehicle(CEntity* entityToRemove) override;
+    void ProcessControlCollisionCheck(bool applySpeed) override;
+    void GetComponentWorldPosition(int32 componentId, CVector& outPos) override;
+    void ProcessOpenDoor(CPed* ped, uint32 doorComponentId, uint32 animGroup, uint32 animId, float fTime) override;
 
     bool IsDoorReady(eDoors door) override { return true; }      // 0x6B58E0
     bool IsDoorFullyOpen(eDoors door) override { return false; } // 0x6B58F0
@@ -108,48 +132,78 @@ public:
     bool IsDoorFullyOpen(uint32 door) override { return false; } // 0x6B5930
     bool IsDoorClosed(uint32 door) override { return false; }    // 0x6B5940
     bool IsDoorMissing(uint32 door) override { return true; }    // 0x6B5950
-
-    void ProcessAI(uint32& arg0);
-
-    // FUNCS
-    CBike(int32 modelIndex, eVehicleCreatedBy createdBy);
-
-    inline bool IsAnyWheelMakingContactWithGround() {
-        return m_fWheelsSuspensionCompression[0] != 1.0F
-            || m_fWheelsSuspensionCompression[1] != 1.0F
-            || m_fWheelsSuspensionCompression[2] != 1.0F
-            || m_fWheelsSuspensionCompression[3] != 1.0F;
-    };
-
-    inline bool IsAnyWheelNotMakingContactWithGround() {
-        return m_fWheelsSuspensionCompression[0] == 1.0F
-            || m_fWheelsSuspensionCompression[1] == 1.0F
-            || m_fWheelsSuspensionCompression[2] == 1.0F
-            || m_fWheelsSuspensionCompression[3] == 1.0F;
-    };
+    
+    bool IsRoomForPedToLeaveCar(uint32 a1, CVector* a2) override { return true; }                        // 0x6B7270
+    inline bool IsComponentPresent(int32 componentId) override { return m_aBikeNodes[componentId] != nullptr; } // 0x6B59E0
+    CRideAnimData* GetRideAnimData() override { return &m_rideAnimData; }                                // 0x6B58C0
+    float GetHeightAboveRoad() override { return m_fHeightAboveRoad; }                                   // 0x6B58B0
+    int32 GetNumContactWheels() override { return m_nNumContactWheels; }                                 // 0x6B58A0
+    float FindWheelWidth(bool bRear) override { return 0.15f; }                                          // 0x6B8940
+    
+    virtual bool ProcessAI(uint32& extraHandlingFlags);
 
     void SetupModelNodes();
     void dmgDrawCarCollidingParticles(const CVector& position, float power, eWeaponType weaponType);
     static bool DamageKnockOffRider(CVehicle* arg0, float arg1, uint16 arg2, CEntity* arg3, CVector& arg4, CVector& arg5);
-    CPed* KnockOffRider(eWeaponType arg0, uint8 arg1, CPed* arg2, bool arg3);
+    CPed* KnockOffRider(eWeaponType arg0, uint8 arg1, CPed* ped, bool arg3);
     void SetRemoveAnimFlags(CPed* ped);
     void ReduceHornCounter();
     void ProcessBuoyancy();
     void inline ProcessPedInVehicleBuoyancy(CPed* ped, bool bIsDriver);
     void ResetSuspension();
-    bool GetAllWheelsOffGround();
-    void DebugCode(); // dummy function
+    [[nodiscard]] bool GetAllWheelsOffGround() const;
+    void DebugCode();
     void DoSoftGroundResistance(uint32& arg0);
     void PlayHornIfNecessary();
     void CalculateLeanMatrix();
-    static void ProcessRiderAnims(CPed* rider, CVehicle* vehicle, CRideAnimData* rideData, tBikeHandlingData* handling);
+    static void ProcessRiderAnims(CPed* rider, CVehicle* vehicle, CRideAnimData* rideData, tBikeHandlingData* handling, int16 a5);
     void FixHandsToBars(CPed* rider);
     void PlaceOnRoadProperly();
     void GetCorrectedWorldDoorPosition(CVector& out, CVector arg1, CVector arg2);
 
+public: // NOTSA
+    inline bool IsAnyWheelMakingContactWithGround() {
+        return m_fWheelsSuspensionCompression[0] != 1.0F
+               || m_fWheelsSuspensionCompression[1] != 1.0F
+               || m_fWheelsSuspensionCompression[2] != 1.0F
+               || m_fWheelsSuspensionCompression[3] != 1.0F;
+    };
+
+    inline bool IsAnyWheelNotMakingContactWithGround() {
+        return m_fWheelsSuspensionCompression[0] == 1.0F
+               || m_fWheelsSuspensionCompression[1] == 1.0F
+               || m_fWheelsSuspensionCompression[2] == 1.0F
+               || m_fWheelsSuspensionCompression[3] == 1.0F;
+    };
+
 private:
-    void BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion);
-    void Fix_Reversed();
+    friend void InjectHooksMain();
+    static void InjectHooks();
+
+    CBike* Constructor(int32 modelIndex, eVehicleCreatedBy createdBy) { this->CBike::CBike(modelIndex, createdBy); return this; }
+    CBike* Destructor() {this->CBike::~CBike(); return this; }
+
+    void Fix_Reversed() { CBike::Fix(); }
+    void BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion) { CBike::BlowUpCar(damager, bHideExplosion); }
+    void ProcessDrivingAnims_Reversed(CPed* driver, uint8 bBlend) { CBike::ProcessDrivingAnims(driver, bBlend); }
+    bool BurstTyre_Reversed(uint8 tyreComponentId, bool bPhysicalEffect) { return CBike::BurstTyre(tyreComponentId, bPhysicalEffect); }
+    void ProcessControlInputs_Reversed(uint8 playerNum) { CBike::ProcessControlInputs(playerNum); }
+    void ProcessEntityCollision_Reversed(CEntity* entity, CColPoint* colPoint) { CBike::ProcessEntityCollision(entity, colPoint); }
+    void Render_Reversed() { CBike::Render(); }
+    void PreRender_Reversed() { CBike::PreRender(); }
+    void Teleport_Reversed(CVector destination, bool resetRotation) { CBike::Teleport(destination, resetRotation); }
+    void ProcessControl_Reversed() { CBike::ProcessControl(); }
+    void VehicleDamage_Reversed(float damageIntensity, uint16 collisionComponent, CEntity* damager, CVector* vecCollisionCoors, CVector* vecCollisionDirection, eWeaponType weapon) { CBike::VehicleDamage(damageIntensity, collisionComponent, damager, vecCollisionCoors, vecCollisionDirection, weapon); }
+    void SetupSuspensionLines_Reversed() { CBike::SetupSuspensionLines(); }
+    void SetModelIndex_Reversed(uint32 index) { CBike::SetModelIndex(index); }
+    void PlayCarHorn_Reversed() { CBike::PlayCarHorn(); }
+    void SetupDamageAfterLoad_Reversed() { CBike::SetupDamageAfterLoad(); }
+    void DoBurstAndSoftGroundRatios_Reversed() { CBike::DoBurstAndSoftGroundRatios(); }
+    bool SetUpWheelColModel_Reversed(CColModel* wheelCol) { return CBike::SetUpWheelColModel(wheelCol); }
+    void RemoveRefsToVehicle_Reversed(CEntity* entityToRemove) { CBike::RemoveRefsToVehicle(entityToRemove); }
+    void ProcessControlCollisionCheck_Reversed(bool applySpeed) { CBike::ProcessControlCollisionCheck(applySpeed); }
+    void GetComponentWorldPosition_Reversed(int32 componentId, CVector& outPos) { CBike::GetComponentWorldPosition(componentId, outPos); }
+    void ProcessOpenDoor_Reversed(CPed* ped, uint32 doorComponentId, uint32 animGroup, uint32 animId, float fTime) { CBike::ProcessOpenDoor(ped, doorComponentId, animGroup, animId, fTime); }
 };
 
 VALIDATE_SIZE(CBike, 0x814);

--- a/source/game_sa/Entity/Vehicle/Bmx.cpp
+++ b/source/game_sa/Entity/Vehicle/Bmx.cpp
@@ -4,10 +4,75 @@ void CBmx::InjectHooks() {
     RH_ScopedClass(CBmx);
     RH_ScopedCategory("Vehicle/Ped");
 
-
+    RH_ScopedInstall(SetUpWheelColModel_Reversed, 0x6BF9B0);
+    RH_ScopedInstall(BurstTyre_Reversed, 0x6BF9C0);
+    RH_ScopedInstall(FindWheelWidth_Reversed, 0x6C0550);
 }
 
-CBmx::CBmx(int32 modelIndex, eVehicleCreatedBy createdBy) : CBike(plugin::dummy)
-{
+CBmx::CBmx(int32 modelIndex, eVehicleCreatedBy createdBy) : CBike(plugin::dummy) {
     plugin::CallMethod<0x6BF820, CBmx*, int32, eVehicleCreatedBy>(this, modelIndex, createdBy);
+}
+
+// 0x6BF9D0
+CBmx::~CBmx() {
+    m_vehicleAudio.Terminate();
+}
+
+// 0x6BF9B0
+bool CBmx::SetUpWheelColModel(CColModel* wheelCol) {
+    return false;
+}
+
+// 0x6BF9C0
+bool CBmx::BurstTyre(uint8 tyreComponentId, bool bPhysicalEffect) {
+    return false;
+}
+
+// 0x6BFA30
+void CBmx::ProcessControl() {
+    plugin::CallMethod<0x6BFA30, CBmx*>(this);
+}
+
+// 0x6BFB50
+void CBmx::ProcessDrivingAnims(CPed* driver, uint8 bBlend) {
+    plugin::CallMethod<0x6BFB50, CBmx*, CPed*, uint8>(this, driver, bBlend);
+}
+
+// 0x6C0390
+void CBmx::LaunchBunnyHopCB(CAnimBlendAssociation* blendAssoc, void* data) {
+    plugin::Call<0x6C0390, CAnimBlendAssociation*, void*>(blendAssoc, data);
+}
+
+// 0x6C0500 | inlined | see 0x6C11F3
+void CBmx::GetFrameOffset(float& a1, float& a2) {
+    const auto d1 = field_760 - field_768;
+    const auto d2 = field_764 - field_76C;
+
+    a1 = (1.0 - m_f830) * d1 + d2 * m_f830;
+    a2 = atan2(d1 - d2, m_fWheelsBalance);
+}
+
+// 0x6C0550
+float CBmx::FindWheelWidth(bool bRear) {
+    return 0.07f;
+}
+
+// 0x6C0560
+void CBmx::BlowUpCar(CEntity* damager, uint8 bHideExplosion) {
+    // NOP
+}
+
+// 0x6C0590
+void CBmx::ProcessBunnyHop() {
+    plugin::CallMethod<0x6C0590, CBmx*>(this);
+}
+
+// 0x6C0810
+void CBmx::PreRender() {
+    plugin::CallMethod<0x6C0810, CBmx*>(this);
+}
+
+// 0x6C1470
+bool CBmx::ProcessAI(uint32& extraHandlingFlags) {
+    return plugin::CallMethodAndReturn<bool, 0x6C1470, CBmx*, uint32>(this, extraHandlingFlags);
 }

--- a/source/game_sa/Entity/Vehicle/Bmx.cpp
+++ b/source/game_sa/Entity/Vehicle/Bmx.cpp
@@ -45,10 +45,10 @@ void CBmx::LaunchBunnyHopCB(CAnimBlendAssociation* blendAssoc, void* data) {
 
 // 0x6C0500 | inlined | see 0x6C11F3
 void CBmx::GetFrameOffset(float& a1, float& a2) {
-    const auto d1 = field_760 - field_768;
-    const auto d2 = field_764 - field_76C;
+    const auto d1 = m_aWheelFrontPosition - m_aWheelBaseFrontPosition;
+    const auto d2 = m_aWheelRearPosition - m_aWheelBaseRearPosition;
 
-    a1 = (1.0 - m_f830) * d1 + d2 * m_f830;
+    a1 = (1.0f - m_f830) * d1 + d2 * m_f830;
     a2 = atan2(d1 - d2, m_fWheelsBalance);
 }
 

--- a/source/game_sa/Entity/Vehicle/Bmx.cpp
+++ b/source/game_sa/Entity/Vehicle/Bmx.cpp
@@ -2,7 +2,7 @@
 
 void CBmx::InjectHooks() {
     RH_ScopedClass(CBmx);
-    RH_ScopedCategory("Vehicle/Ped");
+    RH_ScopedCategory("Vehicle");
 
     RH_ScopedInstall(SetUpWheelColModel_Reversed, 0x6BF9B0);
     RH_ScopedInstall(BurstTyre_Reversed, 0x6BF9C0);

--- a/source/game_sa/Entity/Vehicle/Bmx.h
+++ b/source/game_sa/Entity/Vehicle/Bmx.h
@@ -10,44 +10,65 @@
 #include "AnimBlendAssociation.h"
 
 enum eBmxNodes {
-    BMX_NODE_NONE = 0,
-    BMX_CHASSIS = 1,
+    BMX_NODE_NONE   = 0,
+    BMX_CHASSIS     = 1,
     BMX_FORKS_FRONT = 2,
-    BMX_FORKS_REAR = 3,
+    BMX_FORKS_REAR  = 3,
     BMX_WHEEL_FRONT = 4,
-    BMX_WHEEL_REAR = 5,
-    BMX_HANDLEBARS = 6,
-    BMX_CHAINSET = 7,
-    BMX_PEDAL_R = 8,
-    BMX_PEDAL_L = 9,
+    BMX_WHEEL_REAR  = 5,
+    BMX_HANDLEBARS  = 6,
+    BMX_CHAINSET    = 7,
+    BMX_PEDAL_R     = 8,
+    BMX_PEDAL_L     = 9,
+
     BMX_NUM_NODES
 };
 
 class CBmx : public CBike {
-protected:
-    CBmx(plugin::dummy_func_t) : CBike(plugin::dummy) {}
 public:
-    float field_814;
-    float field_818;
-    float field_81C;
-    float field_820;
-    float field_824;
-    float field_828;
+    float m_fTimeStep; // change name; related to time step
+    float m_fBaseAnimLean;     // always 0.0f
+    float m_fRotPedalChainset; // rotX for BMX_CHAINSET
+    float m_fRotPedalR;        // rotX BMX_PEDAL_R
+    float m_fRotPedalL;        // rotX BMX_PEDAL_L
     float m_fDistanceBetweenWheels;
     float m_fWheelsBalance;
-    uint8 field_834;
+    float m_f830; // see CBmx::GetFrameOffset, ctor
+    bool  m_b831;
 
 public:
+    CBmx(plugin::dummy_func_t) : CBike(plugin::dummy) { /* todo: remove NOTSA */ }
+    CBmx(int32 modelIndex, eVehicleCreatedBy createdBy);
+    ~CBmx() override;
+
+    void BlowUpCar(CEntity* damager, uint8 bHideExplosion) override;
+    bool SetUpWheelColModel(CColModel* wheelCol) override;
+    bool BurstTyre(uint8 tyreComponentId, bool bPhysicalEffect) override;
+    void ProcessControl() override;
+    void ProcessDrivingAnims(CPed* driver, uint8 bBlend) override;
+    float FindWheelWidth(bool bRear) override;
+    void PreRender() override;
+    bool ProcessAI(uint32& extraHandlingFlags) override;
+
+    void GetFrameOffset(float& a1, float& a2);
+    void ProcessBunnyHop();
+    static void LaunchBunnyHopCB(CAnimBlendAssociation* blendAssoc, void* data); // data is a ptr to CBmx
+
+private:
+    friend void InjectHooksMain();
     static void InjectHooks();
 
-    CBmx(int32 modelIndex, eVehicleCreatedBy createdBy);
+    CBmx* Constructor(int32 modelIndex, eVehicleCreatedBy createdBy) { this->CBmx::CBmx(modelIndex, createdBy); return this; }
+    CBmx* Destructor() { this->CBmx::~CBmx(); return this; }
 
-    void BlowUpCar(CEntity* damager, uint8 bHideExplosion) override { /* NOP */ }; // 0x6C0560
-
-    void GetFrameOffset(float& arg0, float& arg1);
-    void ProcessBunnyHop();
-
-    static void LaunchBunnyHopCB(CAnimBlendAssociation* blendAssoc, void* data); // data is a ptr to CBmx
+    void BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion) { CBmx::BlowUpCar(damager, bHideExplosion); }
+    bool SetUpWheelColModel_Reversed(CColModel* wheelCol) { return CBmx::SetUpWheelColModel(wheelCol); }
+    bool BurstTyre_Reversed(uint8 tyreComponentId, bool bPhysicalEffect) { return CBmx::BurstTyre(tyreComponentId, bPhysicalEffect); }
+    void ProcessControl_Reversed() { CBmx::ProcessControl(); }
+    void ProcessDrivingAnims_Reversed(CPed* driver, uint8 bBlend) { CBmx::ProcessDrivingAnims(driver, bBlend); }
+    float FindWheelWidth_Reversed(bool bRear) { return CBmx::FindWheelWidth(bRear); }
+    void PreRender_Reversed() { CBmx::PreRender(); }
+    bool ProcessAI_Reversed(uint32& extraHandlingFlags) { return CBmx::ProcessAI(extraHandlingFlags); }
 };
 
 VALIDATE_SIZE(CBmx, 0x838);

--- a/source/game_sa/Entity/Vehicle/Bmx.h
+++ b/source/game_sa/Entity/Vehicle/Bmx.h
@@ -26,7 +26,7 @@ enum eBmxNodes {
 
 class CBmx : public CBike {
 public:
-    float m_fTimeStep; // change name; related to time step
+    float m_fTimeStep;         // todo: change name; related to time step
     float m_fBaseAnimLean;     // always 0.0f
     float m_fRotPedalChainset; // rotX for BMX_CHAINSET
     float m_fRotPedalR;        // rotX BMX_PEDAL_R

--- a/source/game_sa/Entity/Vehicle/Boat.cpp
+++ b/source/game_sa/Entity/Vehicle/Boat.cpp
@@ -101,7 +101,7 @@ CBoat::CBoat(int32 modelIndex, eVehicleCreatedBy createdBy) : CVehicle(createdBy
     memset(m_afWakePointLifeTime, 0, sizeof(m_afWakePointLifeTime));
 
     m_nAmmoInClip = 20;
-    m_boatFlap.m_nAxis = eRotationAxis::AXIS_Y;
+    m_boatFlap.m_nAxis = AXIS_Y;
     if (m_nModelIndex == MODEL_MARQUIS) {
         m_boatFlap.m_fOpenAngle = PI / 10.0F;
         m_boatFlap.m_fClosedAngle = -PI / 10.0F;
@@ -404,7 +404,7 @@ void CBoat::ProcessControl_Reversed() {
         m_nBoatFlags.bAnchored = false;
         m_fAnchoredAngle = -10000.0f;
         if (m_pDriver)
-            this->ProcessControlInputs(m_pDriver->m_nPedType);
+            ProcessControlInputs(m_pDriver->m_nPedType);
 
         if (m_nModelIndex == MODEL_PREDATOR)
             CVehicle::DoFixedMachineGuns();
@@ -527,7 +527,7 @@ void CBoat::ProcessControl_Reversed() {
 
                 m_fBurningTimer += (CTimer::GetTimeStep() * 20.0F);
                 if (m_fBurningTimer > 5000.0F)
-                    this->BlowUpCar(m_pWhoDestroyedMe, false);
+                    BlowUpCar(m_pWhoDestroyedMe, false);
             }
         }
     }
@@ -575,9 +575,9 @@ void CBoat::PreRender_Reversed() {
 
     m_fContactSurfaceBrightness = 0.5F;
     auto fUsedAngle = -m_fSteerAngle;
-    CVehicle::SetComponentRotation(m_aBoatNodes[eBoatNodes::BOAT_RUDDER],         eRotationAxis::AXIS_Z, fUsedAngle, true);
-    CVehicle::SetComponentRotation(m_aBoatNodes[eBoatNodes::BOAT_REARFLAP_LEFT],  eRotationAxis::AXIS_Z, fUsedAngle, true);
-    CVehicle::SetComponentRotation(m_aBoatNodes[eBoatNodes::BOAT_REARFLAP_RIGHT], eRotationAxis::AXIS_Z, fUsedAngle, true);
+    SetComponentRotation(m_aBoatNodes[BOAT_RUDDER],         AXIS_Z, fUsedAngle, true);
+    SetComponentRotation(m_aBoatNodes[BOAT_REARFLAP_LEFT],  AXIS_Z, fUsedAngle, true);
+    SetComponentRotation(m_aBoatNodes[BOAT_REARFLAP_RIGHT], AXIS_Z, fUsedAngle, true);
 
     auto fPropSpeed = std::min(1.0F, m_fPropSpeed * (32.0F / TWO_PI));
     auto ucTransparency = static_cast<RwUInt8>((1.0F - fPropSpeed) * 255.0F);
@@ -586,15 +586,15 @@ void CBoat::PreRender_Reversed() {
     while (m_fPropRotation > TWO_PI)
         m_fPropRotation -= TWO_PI;
 
-    ProcessBoatNodeRendering(eBoatNodes::BOAT_STATIC_PROP,   m_fPropRotation * 2,  ucTransparency);
-    ProcessBoatNodeRendering(eBoatNodes::BOAT_STATIC_PROP_2, m_fPropRotation * -2, ucTransparency);
+    ProcessBoatNodeRendering(BOAT_STATIC_PROP,   m_fPropRotation * 2,  ucTransparency);
+    ProcessBoatNodeRendering(BOAT_STATIC_PROP_2, m_fPropRotation * -2, ucTransparency);
 
     ucTransparency = (ucTransparency >= 150 ? 0 : 150 - ucTransparency);
-    ProcessBoatNodeRendering(eBoatNodes::BOAT_MOVING_PROP,  -m_fPropRotation, ucTransparency);
-    ProcessBoatNodeRendering(eBoatNodes::BOAT_MOVING_PROP_2, m_fPropRotation, ucTransparency);
+    ProcessBoatNodeRendering(BOAT_MOVING_PROP,  -m_fPropRotation, ucTransparency);
+    ProcessBoatNodeRendering(BOAT_MOVING_PROP_2, m_fPropRotation, ucTransparency);
 
     if (m_nModelIndex == MODEL_MARQUIS) {
-        auto pFlap = m_aBoatNodes[eBoatNodes::BOAT_FLAP_LEFT];
+        auto pFlap = m_aBoatNodes[BOAT_FLAP_LEFT];
         if (pFlap) {
             auto tempMat = CMatrix();
             tempMat.Attach(RwFrameGetMatrix(pFlap), false);
@@ -603,11 +603,11 @@ void CBoat::PreRender_Reversed() {
 
             m_boatFlap.Process(this, m_vecBoatMoveForce, m_vecBoatTurnForce, vecTransformed);
             CVector vecAxis;
-            if (m_boatFlap.m_nAxis == eRotationAxis::AXIS_X)
+            if (m_boatFlap.m_nAxis == AXIS_X)
                 vecAxis.Set(m_boatFlap.m_fAngle, 0.0F, 0.0F);
-            else if (m_boatFlap.m_nAxis == eRotationAxis::AXIS_Y)
+            else if (m_boatFlap.m_nAxis == AXIS_Y)
                 vecAxis.Set(0.0F, m_boatFlap.m_fAngle, 0.0F);
-            else if (m_boatFlap.m_nAxis == eRotationAxis::AXIS_Z)
+            else if (m_boatFlap.m_nAxis == AXIS_Z)
                 vecAxis.Set(0.0F, 0.0F, m_boatFlap.m_fAngle);
 
             tempMat.SetRotate(vecAxis.x, vecAxis.y, vecAxis.z);
@@ -620,9 +620,9 @@ void CBoat::PreRender_Reversed() {
         || m_nModelIndex == MODEL_REEFER
         || m_nModelIndex == MODEL_TROPIC) {
 
-        auto moving = m_aBoatNodes[eBoatNodes::BOAT_MOVING];
+        auto moving = m_aBoatNodes[BOAT_MOVING];
         if (moving) {
-            CVehicle::SetComponentRotation(moving, eRotationAxis::AXIS_Z, this->m_fMovingHiRotation, true);
+            SetComponentRotation(moving, AXIS_Z, m_fMovingHiRotation, true);
             if (CCheat::IsActive(CHEAT_INVISIBLE_CAR))
             {
                 auto firstObj = reinterpret_cast<RpAtomic*>(GetFirstObject(moving));
@@ -637,7 +637,7 @@ void CBoat::PreRender_Reversed() {
     auto fSpeed = m_vecMoveSpeed.Magnitude();
 
     int32 iCounter = 0;
-    constexpr eBoatNodes aCheckedNodes[2] = { eBoatNodes::BOAT_STATIC_PROP, eBoatNodes::BOAT_STATIC_PROP_2 };
+    constexpr eBoatNodes aCheckedNodes[2] = { BOAT_STATIC_PROP, BOAT_STATIC_PROP_2 };
     for (const auto eNode : aCheckedNodes) {
         auto prop = m_aBoatNodes[eNode];
         RwMatrix* splashMat = CEntity::GetModellingMatrix();
@@ -683,7 +683,7 @@ inline void CBoat::ProcessBoatNodeRendering(eBoatNodes eNode, float fRotation, R
     if (!frame)
         return;
 
-    CVehicle::SetComponentRotation(frame, eRotationAxis::AXIS_Y, fRotation, true);
+    SetComponentRotation(frame, AXIS_Y, fRotation, true);
     RpAtomic* atomic;
     RwFrameForAllObjects(frame, GetCurrentAtomicObjectCB, &atomic);
     if (atomic)
@@ -885,7 +885,7 @@ void CBoat::BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion) {
     CExplosion::AddExplosion(this, damager, eExplosionType::EXPLOSION_BOAT, vecPos, 0, 1, -1.0F, bHideExplosion);
     CDarkel::RegisterCarBlownUpByPlayer(this, 0);
 
-    auto movingComponent = m_aBoatNodes[eBoatNodes::BOAT_MOVING];
+    auto movingComponent = m_aBoatNodes[BOAT_MOVING];
     if (!movingComponent)
         return;
 

--- a/source/game_sa/Entity/Vehicle/Boat.cpp
+++ b/source/game_sa/Entity/Vehicle/Boat.cpp
@@ -19,7 +19,7 @@ RxVertexIndex* CBoat::auRenderIndices = (RxVertexIndex*)0xC27988;
 
 void CBoat::InjectHooks() {
     RH_ScopedClass(CBoat);
-    RH_ScopedCategory("Vehicle/Ped");
+    RH_ScopedCategory("Vehicle");
 
     RH_ScopedInstall(SetModelIndex_Reversed, 0x6F1140);
     RH_ScopedInstall(ProcessControl_Reversed, 0x6F1770);

--- a/source/game_sa/Entity/Vehicle/Boat.cpp
+++ b/source/game_sa/Entity/Vehicle/Boat.cpp
@@ -4,25 +4,23 @@
 #include "CarCtrl.h"
 
 CBoat* (&CBoat::apFrameWakeGeneratingBoats)[NUM_WAKE_GEN_BOATS] = *(CBoat*(*)[NUM_WAKE_GEN_BOATS])0xC27994;
-float& CBoat::MAX_WAKE_LENGTH = *(float*)0x8D3938; // 50.0
-float& CBoat::MIN_WAKE_INTERVAL = *(float*)0x8D393C; // 2.0
-float& CBoat::WAKE_LIFETIME = *(float*)0x8D3940; // 150.0
-float& CBoat::fShapeLength = *(float*)0x8D3944; // 0.4
-float& CBoat::fShapeTime = *(float*)0x8D3948; // 0.05
-float& CBoat::fRangeMult = *(float*)0x8D394C; // 0.6
+float& CBoat::MAX_WAKE_LENGTH = *(float*)0x8D3938;   // 50.0f
+float& CBoat::MIN_WAKE_INTERVAL = *(float*)0x8D393C; // 2.0f
+float& CBoat::WAKE_LIFETIME = *(float*)0x8D3940;     // 150.0f
+float& CBoat::fShapeLength = *(float*)0x8D3944;      // 0.4f
+float& CBoat::fShapeTime = *(float*)0x8D3948;        // 0.05f
+float& CBoat::fRangeMult = *(float*)0x8D394C;        // 0.6f
 
-int16* CBoat::waUnknArr = (int16*)0xC279A4;
-int16* CBoat::waUnknArr2 = (int16*)0xC279AC;
+int16 (&CBoat::waUnknArr)[4] = *(int16(*)[4])0xC279A4;
+int16 (&CBoat::waUnknArr2)[4] = *(int16(*)[4])0xC279AC;
 
 RxObjSpace3DVertex* CBoat::aRenderVertices = (RxObjSpace3DVertex*)0xC278F8;
 RxVertexIndex* CBoat::auRenderIndices = (RxVertexIndex*)0xC27988;
 
-void CBoat::InjectHooks()
-{
+void CBoat::InjectHooks() {
     RH_ScopedClass(CBoat);
     RH_ScopedCategory("Vehicle/Ped");
 
-    //Virtual
     RH_ScopedInstall(SetModelIndex_Reversed, 0x6F1140);
     RH_ScopedInstall(ProcessControl_Reversed, 0x6F1770);
     RH_ScopedInstall(Teleport_Reversed, 0x6F20E0);
@@ -32,16 +30,12 @@ void CBoat::InjectHooks()
     RH_ScopedInstall(GetComponentWorldPosition_Reversed, 0x6F01D0);
     RH_ScopedInstall(ProcessOpenDoor_Reversed, 0x6F0190);
     RH_ScopedInstall(BlowUpCar_Reversed, 0x6F21B0);
-
-    //Class methods
     RH_ScopedInstall(PruneWakeTrail, 0x6F0E20);
     RH_ScopedInstall(AddWakePoint, 0x6F2550);
     RH_ScopedInstall(SetupModelNodes, 0x6F01A0);
     RH_ScopedInstall(DebugCode, 0x6F0D00);
     RH_ScopedInstall(ModifyHandlingValue, 0x6F0DE0);
     RH_ScopedInstall(PrintThrustAndRudderInfo, 0x6F0D90);
-
-    //Other
     RH_ScopedInstall(FillBoatList, 0x6F2710);
     RH_ScopedInstall(IsSectorAffectedByWake, 0x6F0E80);
     RH_ScopedInstall(IsVertexAffectedByWake, 0x6F0F50);
@@ -49,11 +43,13 @@ void CBoat::InjectHooks()
     RH_ScopedGlobalInstall(GetBoatAtomicObjectCB, 0x6F00D0);
 }
 
-CBoat::CBoat(int32 modelIndex, eVehicleCreatedBy createdBy) : CVehicle(createdBy)
-{
+// 0x6F2940
+CBoat::CBoat(int32 modelIndex, eVehicleCreatedBy createdBy) : CVehicle(createdBy) {
+    // plugin::CallMethod<0x6F2940, CBoat*, int32, eVehicleCreatedBy>(this, modelIndex, createdBy);
+    // return;
+
     memset(&m_boatFlap, 0, sizeof(m_boatFlap));
     CVehicleModelInfo* mi = CModelInfo::GetModelInfo(modelIndex)->AsVehicleModelInfoPtr();
-    const auto iHandlingId = mi->m_nHandlingId;
     m_nVehicleType = VEHICLE_TYPE_BOAT;
     m_nVehicleSubType = VEHICLE_TYPE_BOAT;
     m_vecBoatMoveForce.Set(0.0F, 0.0F, 0.0F);
@@ -66,10 +62,10 @@ CBoat::CBoat(int32 modelIndex, eVehicleCreatedBy createdBy) : CVehicle(createdBy
     CVehicle::SetModelIndex(modelIndex);
     SetupModelNodes();
 
-    m_pHandlingData = &gHandlingDataMgr.m_aVehicleHandling[iHandlingId];
+    m_pHandlingData = gHandlingDataMgr.GetVehiclePointer(mi->m_nHandlingId);
     m_nHandlingFlagsIntValue = m_pHandlingData->m_nHandlingFlags;
-    m_pFlyingHandlingData = gHandlingDataMgr.GetFlyingPointer(iHandlingId);
-    m_pBoatHandling = gHandlingDataMgr.GetBoatPointer(iHandlingId);
+    m_pFlyingHandlingData = gHandlingDataMgr.GetFlyingPointer(mi->m_nHandlingId);
+    m_pBoatHandling = gHandlingDataMgr.GetBoatPointer(mi->m_nHandlingId);
 
     mi->ChooseVehicleColour(m_nPrimaryColor, m_nSecondaryColor, m_nTertiaryColor, m_nQuaternaryColor, 1);
 
@@ -106,14 +102,11 @@ CBoat::CBoat(int32 modelIndex, eVehicleCreatedBy createdBy) : CVehicle(createdBy
 
     m_nAmmoInClip = 20;
     m_boatFlap.m_nAxis = eRotationAxis::AXIS_Y;
-    if (m_nModelIndex == MODEL_MARQUIS)
-    {
+    if (m_nModelIndex == MODEL_MARQUIS) {
         m_boatFlap.m_fOpenAngle = PI / 10.0F;
         m_boatFlap.m_fClosedAngle = -PI / 10.0F;
         m_boatFlap.m_nDirn = 4;
-    }
-    else
-    {
+    } else {
         m_boatFlap.m_fOpenAngle = TWO_PI / 10.0F;
         m_boatFlap.m_fClosedAngle = -TWO_PI / 10.0F;
         m_boatFlap.m_nDirn = 3;
@@ -124,77 +117,29 @@ CBoat::CBoat(int32 modelIndex, eVehicleCreatedBy createdBy) : CVehicle(createdBy
         fx = nullptr;
 }
 
-CBoat::~CBoat()
-{
+// 0x6F00F0
+CBoat::~CBoat() {
     if (m_pFireParticle) {
         m_pFireParticle->Kill();
         m_pFireParticle = nullptr;
     }
 
-    for (auto& pSplashPart : m_apPropSplashFx) {
-        if (!pSplashPart)
-            continue;
-
-        pSplashPart->Kill();
-        pSplashPart = nullptr;
+    for (auto& fx : m_apPropSplashFx) {
+        if (fx) {
+            fx->Kill();
+            fx = nullptr;
+        }
     }
 
     m_vehicleAudio.Terminate();
 }
 
-void CBoat::SetModelIndex(uint32 index)
-{
-    return CBoat::SetModelIndex_Reversed(index);
-}
-
-void CBoat::ProcessControl()
-{
-    return CBoat::ProcessControl_Reversed();
-}
-
-void CBoat::Teleport(CVector destination, bool resetRotation)
-{
-    return CBoat::Teleport_Reversed(destination, resetRotation);
-}
-
-void CBoat::PreRender()
-{
-    return CBoat::PreRender_Reversed();
-}
-
-void CBoat::Render()
-{
-    return CBoat::Render_Reversed();
-}
-
-void CBoat::ProcessControlInputs(uint8 playerNum)
-{
-    return CBoat::ProcessControlInputs_Reversed(playerNum);
-}
-
-void CBoat::GetComponentWorldPosition(int32 componentId, CVector& outPos)
-{
-    return CBoat::GetComponentWorldPosition_Reversed(componentId, outPos);
-}
-
-void CBoat::ProcessOpenDoor(CPed* ped, uint32 doorComponentId, uint32 animGroup, uint32 arg3, float arg4)
-{
-    return CBoat::ProcessOpenDoor_Reversed(ped, doorComponentId, animGroup, arg3, arg4);
-}
-
-void CBoat::BlowUpCar(CEntity* damager, uint8 bHideExplosion)
-{
-    return CBoat::BlowUpCar_Reversed(damager, bHideExplosion);
-}
-
-inline void CBoat::SetupModelNodes()
-{
+inline void CBoat::SetupModelNodes() {
     memset(m_aBoatNodes, 0, sizeof(m_aBoatNodes));
     CClumpModelInfo::FillFrameArray(m_pRwClump, m_aBoatNodes);
 }
 
-void CBoat::DebugCode()
-{
+void CBoat::DebugCode() {
     if (FindPlayerVehicle() != AsVehicle())
         return;
 
@@ -210,15 +155,15 @@ void CBoat::DebugCode()
     SetupModelNodes();
 }
 
-void CBoat::PrintThrustAndRudderInfo()
-{
+// uses debug printing
+// 0x6F0D90
+void CBoat::PrintThrustAndRudderInfo() {
     char cBuffer[64];
     sprintf(cBuffer, "Thrust %3.2f", m_pHandlingData->m_transmissionData.m_fEngineAcceleration * m_pHandlingData->m_fMass);
     sprintf(cBuffer, "Rudder Angle  %3.2f", m_pHandlingData->m_fSteeringLock);
 }
 
-void CBoat::ModifyHandlingValue(const bool& bIncrement)
-{
+void CBoat::ModifyHandlingValue(const bool& bIncrement) {
     auto fChange = -1.0F;
     if (bIncrement)
         fChange = 1.0F;
@@ -227,8 +172,7 @@ void CBoat::ModifyHandlingValue(const bool& bIncrement)
         m_pHandlingData->m_fSteeringLock += fChange;
 }
 
-void CBoat::PruneWakeTrail()
-{
+void CBoat::PruneWakeTrail() {
     int16 iInd;
     for (iInd = 0; iInd < 32; ++iInd) {
         auto fPointLifeTime = m_afWakePointLifeTime[iInd];
@@ -249,8 +193,7 @@ void CBoat::PruneWakeTrail()
     m_nNumWaterTrailPoints = iInd;
 }
 
-void CBoat::AddWakePoint(CVector posn)
-{
+void CBoat::AddWakePoint(CVector posn) {
     auto ucIntensity = static_cast<uint8>(m_vecMoveSpeed.Magnitude() * 100.0F);
 
     // No wake points existing, early out
@@ -291,27 +234,24 @@ void CBoat::AddWakePoint(CVector posn)
         ++m_nNumWaterTrailPoints;
 }
 
-bool CBoat::IsSectorAffectedByWake(CVector2D vecPos, float fOffset, CBoat** ppBoats)
-{
+bool CBoat::IsSectorAffectedByWake(CVector2D vecPos, float fOffset, CBoat** ppBoats) {
     if (!apFrameWakeGeneratingBoats[0])
         return false;
 
     bool bWakeFound = false;
-    for (int32 i = 0; i < NUM_WAKE_GEN_BOATS; ++i) {
-        auto pBoat = apFrameWakeGeneratingBoats[i];
-        if (!pBoat)
+    for (auto& boat : apFrameWakeGeneratingBoats) {
+        if (!boat)
             continue;
 
-        if (!pBoat->m_nNumWaterTrailPoints)
+        if (!boat->m_nNumWaterTrailPoints)
             continue;
 
-        for (int32 iTrail = 0; iTrail < pBoat->m_nNumWaterTrailPoints; ++iTrail) {
-            auto fDist = (WAKE_LIFETIME - pBoat->m_afWakePointLifeTime[iTrail]) * fShapeTime + static_cast<float>(iTrail) * fShapeLength + fOffset;
-            if (fabs(pBoat->m_avecWakePoints[iTrail].x - vecPos.x) >= fDist
-                || fabs(pBoat->m_avecWakePoints[iTrail].y - vecPos.y) >= fDist)
+        for (int32 iTrail = 0; iTrail < boat->m_nNumWaterTrailPoints; ++iTrail) {
+            auto fDist = (WAKE_LIFETIME - boat->m_afWakePointLifeTime[iTrail]) * fShapeTime + static_cast<float>(iTrail) * fShapeLength + fOffset;
+            if (fabs(boat->m_avecWakePoints[iTrail].x - vecPos.x) >= fDist || fabs(boat->m_avecWakePoints[iTrail].y - vecPos.y) >= fDist)
                 continue;
 
-            ppBoats[bWakeFound] = pBoat;
+            ppBoats[bWakeFound] = boat;
             bWakeFound = true;
             break;
         }
@@ -320,25 +260,22 @@ bool CBoat::IsSectorAffectedByWake(CVector2D vecPos, float fOffset, CBoat** ppBo
     return bWakeFound;
 }
 
-float CBoat::IsVertexAffectedByWake(CVector vecPos, CBoat* pBoat, int16 wIndex, bool bUnkn)
-{
+float CBoat::IsVertexAffectedByWake(CVector vecPos, CBoat* boat, int16 wIndex, bool bUnkn) {
     if (bUnkn) {
         waUnknArr[wIndex] = 0;
         waUnknArr2[wIndex] = 8;
-    }
-    else if (waUnknArr[wIndex] > 0)
+    } else if (waUnknArr[wIndex] > 0)
         return 0.0F;
 
-    if (!pBoat->m_nNumWaterTrailPoints)
+    if (!boat->m_nNumWaterTrailPoints)
         return 0.0F;
 
-    for (int32 iTrail = 0; iTrail < pBoat->m_nNumWaterTrailPoints; ++iTrail) {
-        auto fWakeDistSquared = powf((WAKE_LIFETIME - pBoat->m_afWakePointLifeTime[iTrail]) * fShapeTime + static_cast<float>(iTrail) * fShapeLength, 2);
-        auto fTrailDistSquared = (pBoat->m_avecWakePoints[iTrail] - vecPos).SquaredMagnitude();
-        if (fTrailDistSquared < fWakeDistSquared)
-        {
+    for (int32 iTrail = 0; iTrail < boat->m_nNumWaterTrailPoints; ++iTrail) {
+        auto fWakeDistSquared = powf((WAKE_LIFETIME - boat->m_afWakePointLifeTime[iTrail]) * fShapeTime + static_cast<float>(iTrail) * fShapeLength, 2);
+        auto fTrailDistSquared = (boat->m_avecWakePoints[iTrail] - vecPos).SquaredMagnitude();
+        if (fTrailDistSquared < fWakeDistSquared) {
             waUnknArr2[wIndex] = 0;
-            float fContrib = sqrtf(fTrailDistSquared / fWakeDistSquared) * fRangeMult + (WAKE_LIFETIME - pBoat->m_afWakePointLifeTime[iTrail]) * 1.2F / WAKE_LIFETIME;
+            float fContrib = sqrtf(fTrailDistSquared / fWakeDistSquared) * fRangeMult + (WAKE_LIFETIME - boat->m_afWakePointLifeTime[iTrail]) * 1.2F / WAKE_LIFETIME;
             fContrib = std::min(1.0F, fContrib);
             return 1.0F - fContrib;
         }
@@ -347,8 +284,7 @@ float CBoat::IsVertexAffectedByWake(CVector vecPos, CBoat* pBoat, int16 wIndex, 
         if (fDistDiff > 20.0F) {
             if (waUnknArr2[wIndex] > 3)
                 waUnknArr2[wIndex] = 3;
-        }
-        else if (fDistDiff > 10.0F) {
+        } else if (fDistDiff > 10.0F) {
             if (waUnknArr2[wIndex] > 2)
                 waUnknArr2[wIndex] = 2;
         }
@@ -357,8 +293,7 @@ float CBoat::IsVertexAffectedByWake(CVector vecPos, CBoat* pBoat, int16 wIndex, 
     return 0.0F;
 }
 
-void CBoat::CheckForSkippingCalculations()
-{
+void CBoat::CheckForSkippingCalculations() {
     for (size_t ind = 0; ind < 4; ++ind) {
         auto iVal = waUnknArr2[ind];
         if (iVal <= 0 || iVal >= 8) {
@@ -367,8 +302,7 @@ void CBoat::CheckForSkippingCalculations()
                 continue;
             }
             waUnknArr[ind] = iVal - 1;
-        }
-        else if (iVal <= waUnknArr[ind] - 1)
+        } else if (iVal <= waUnknArr[ind] - 1)
             --waUnknArr[ind];
 
         waUnknArr2[ind] = 8;
@@ -376,10 +310,9 @@ void CBoat::CheckForSkippingCalculations()
 }
 
 // 0x6F2710
-void CBoat::FillBoatList()
-{
-    for (int32 i = 0; i < NUM_WAKE_GEN_BOATS; i++)
-        apFrameWakeGeneratingBoats[i] = nullptr;
+void CBoat::FillBoatList() {
+    for (auto& boat : apFrameWakeGeneratingBoats)
+        boat = nullptr;
 
     auto vecCamPos = CVector2D(TheCamera.GetPosition());
     auto vecCamDir = CVector2D(TheCamera.m_mCameraMatrix.GetForward());
@@ -435,8 +368,7 @@ void CBoat::FillBoatList()
     }
 }
 
-void CBoat::SetModelIndex_Reversed(uint32 index)
-{
+void CBoat::SetModelIndex_Reversed(uint32 index) {
     CVehicle::SetModelIndex(index);
     memset(m_aBoatNodes, 0, sizeof(m_aBoatNodes));
     CClumpModelInfo::FillFrameArray(m_pRwClump, m_aBoatNodes);
@@ -455,8 +387,8 @@ void CBoat::ProcessControl_Reversed() {
         auto pPlayerVeh = FindPlayerVehicle();
         if (pPlayerVeh && pPlayerVeh->GetVehicleAppearance() == eVehicleAppearance::VEHICLE_APPEARANCE_BOAT) {
             auto iCarMission = m_autoPilot.m_nCarMission;
-            if (iCarMission == eCarMission::MISSION_ATTACKPLAYER
-                || (iCarMission >= eCarMission::MISSION_RAMPLAYER_FARAWAY && iCarMission <= eCarMission::MISSION_BLOCKPLAYER_CLOSE)) {
+            if (iCarMission == eCarMission::MISSION_ATTACKPLAYER ||
+                (iCarMission >= eCarMission::MISSION_RAMPLAYER_FARAWAY && iCarMission <= eCarMission::MISSION_BLOCKPLAYER_CLOSE)) {
 
                 if (static_cast<uint32>(CTimer::GetTimeInMS()) > m_nAttackPlayerTime)
                     m_nAttackPlayerTime = rand() % 4096 + CTimer::GetTimeInMS() + 4500;
@@ -466,6 +398,7 @@ void CBoat::ProcessControl_Reversed() {
 
     CVehicle::UpdateClumpAlpha();
     CVehicle::ProcessCarAlarm();
+
     switch (m_nStatus) {
     case eEntityStatus::STATUS_PLAYER:
         m_nBoatFlags.bAnchored = false;
@@ -526,13 +459,11 @@ void CBoat::ProcessControl_Reversed() {
         else if (m_fGasPedal < 0.0F) {
             fSTDPropSpeed = (CPlane::PLANE_STD_PROP_SPEED - 0.05F) * m_fGasPedal + CPlane::PLANE_STD_PROP_SPEED;
             m_fPropSpeed += (fSTDPropSpeed - m_fPropSpeed) * CTimer::GetTimeStep() * fROCPropSpeed;
-        }
-        else {
+        } else {
             fSTDPropSpeed = (CPlane::PLANE_MAX_PROP_SPEED - CPlane::PLANE_STD_PROP_SPEED) * m_fGasPedal + CPlane::PLANE_STD_PROP_SPEED;
             m_fPropSpeed += (fSTDPropSpeed - m_fPropSpeed) * CTimer::GetTimeStep() * fROCPropSpeed;
         }
-    }
-    else if (m_fPropSpeed > 0.0F)
+    } else if (m_fPropSpeed > 0.0F)
         m_fPropSpeed *= 0.95F;
 
     auto fDamagePower = m_fDamageIntensity * m_pHandlingData->m_fCollisionDamageMultiplier;
@@ -542,15 +473,13 @@ void CBoat::ProcessControl_Reversed() {
             fDamagePower *= 0.5F;
 
         auto fGivenDamage = fDamagePower;
-        if (this == FindPlayerVehicle()->AsBoat())
-        {
+        if (this == FindPlayerVehicle()->AsBoat()) {
             fGivenDamage -= 25.0F;
             if (vehicleFlags.bTakeLessDamage)
                 fGivenDamage /= 6.0F;
             else
                 fGivenDamage *= 0.5F;
-        }
-        else {
+        } else {
             if (fGivenDamage > 60.0F && m_pDriver)
                 m_pDriver->Say(0x44U, 0, 1.0F, 0, 0, 0);
 
@@ -574,8 +503,7 @@ void CBoat::ProcessControl_Reversed() {
             m_pFireParticle->Kill();
             m_pFireParticle = nullptr;
         }
-    }
-    else {
+    } else {
         auto vecDist = GetPosition() - TheCamera.GetPosition();
         if (fabs(vecDist.x) < 200.0F && fabs(vecDist.y) < 200.0F) {
 
@@ -587,9 +515,8 @@ void CBoat::ProcessControl_Reversed() {
 
             if (m_fHealth < 250.0F) {
                 if (!m_pFireParticle) {
-                    auto pModellingMat = GetModellingMatrix();
-                    if (pModellingMat) {
-                        m_pFireParticle = g_fxMan.CreateFxSystem("fire_car", &vecFirePos, pModellingMat, 0);
+                    if (auto modellingMat = GetModellingMatrix()) {
+                        m_pFireParticle = g_fxMan.CreateFxSystem("fire_car", &vecFirePos, modellingMat, false);
                         if (m_pFireParticle) {
                             m_pFireParticle->Play();
                             CEventVehicleOnFire vehOnFireEvent(this);
@@ -612,9 +539,9 @@ void CBoat::ProcessControl_Reversed() {
     if (m_nModelIndex == MODEL_SKIMMER
         && (m_fPropSpeed > CPlane::PLANE_MIN_PROP_SPEED || m_vecMoveSpeed.SquaredMagnitude() > CPlane::PLANE_MIN_PROP_SPEED)) {
         FlyingControl(FLIGHT_MODEL_PLANE, -10000.0f, -10000.0f, -10000.0f, -10000.0f);
-    }
-    else if (CCheat::m_aCheatsActive[eCheats::CHEAT_BOATS_FLY])
+    } else if (CCheat::m_aCheatsActive[eCheats::CHEAT_BOATS_FLY]) {
         FlyingControl(FLIGHT_MODEL_BOAT, -10000.0f, -10000.0f, -10000.0f, -10000.0f);
+    }
 
     if (m_nBoatFlags.bAnchored) {
         m_vecMoveSpeed.x = 0.0F;
@@ -631,8 +558,7 @@ void CBoat::ProcessControl_Reversed() {
     }
 }
 
-void CBoat::Teleport_Reversed(CVector destination, bool resetRotation)
-{
+void CBoat::Teleport_Reversed(CVector destination, bool resetRotation) {
     CWorld::Remove(this);
     SetPosn(destination);
     if (resetRotation)
@@ -643,8 +569,7 @@ void CBoat::Teleport_Reversed(CVector destination, bool resetRotation)
     CWorld::Add(this);
 }
 
-void CBoat::PreRender_Reversed()
-{
+void CBoat::PreRender_Reversed() {
     CVehicle::PreRender();
 
     m_fContactSurfaceBrightness = 0.5F;
@@ -690,16 +615,12 @@ void CBoat::PreRender_Reversed()
         }
     }
 
-    if (m_nModelIndex == MODEL_PREDATOR
-        || m_nModelIndex == MODEL_REEFER
-        || m_nModelIndex == MODEL_TROPIC) {
-
-        auto pMoving = m_aBoatNodes[eBoatNodes::BOAT_MOVING];
-        if (pMoving) {
-            CVehicle::SetComponentRotation(pMoving, eRotationAxis::AXIS_Z, this->m_fMovingHiRotation, 1);
-            if (CCheat::m_aCheatsActive[CHEAT_INVISIBLE_CAR])
-            {
-                auto pFirstObj = reinterpret_cast<RpAtomic*>(GetFirstObject(pMoving));
+    if (m_nModelIndex == MODEL_PREDATOR || m_nModelIndex == MODEL_REEFER || m_nModelIndex == MODEL_TROPIC) {
+        auto moving = m_aBoatNodes[eBoatNodes::BOAT_MOVING];
+        if (moving) {
+            CVehicle::SetComponentRotation(moving, eRotationAxis::AXIS_Z, m_fMovingHiRotation, true);
+            if (CCheat::m_aCheatsActive[CHEAT_INVISIBLE_CAR]) {
+                auto pFirstObj = reinterpret_cast<RpAtomic*>(GetFirstObject(moving));
                 RpAtomicRenderMacro(pFirstObj);
             }
         }
@@ -740,8 +661,7 @@ void CBoat::PreRender_Reversed()
                 splashFx->SetMatrix(splashMat);
                 auto fTime = std::min(1.0F, fSpeed * 2.0F);
                 splashFx->SetConstTime(true, fTime);
-            }
-            else if (splashFx->GetPlayStatus() == eFxSystemPlayStatus::FX_PLAYING) {
+            } else if (splashFx->GetPlayStatus() == eFxSystemPlayStatus::FX_PLAYING) {
                 splashFx->Stop();
             }
         }
@@ -753,8 +673,7 @@ void CBoat::PreRender_Reversed()
     CVehicle::DoBoatSplashes(fWaterDamping);
 }
 
-inline void CBoat::ProcessBoatNodeRendering(eBoatNodes eNode, float fRotation, RwUInt8 ucAlpha)
-{
+inline void CBoat::ProcessBoatNodeRendering(eBoatNodes eNode, float fRotation, RwUInt8 ucAlpha) {
     auto frame = m_aBoatNodes[eNode];
     if (!frame)
         return;
@@ -766,8 +685,7 @@ inline void CBoat::ProcessBoatNodeRendering(eBoatNodes eNode, float fRotation, R
         CVehicle::SetComponentAtomicAlpha(atomic, ucAlpha);
 }
 
-void CBoat::Render_Reversed()
-{
+void CBoat::Render_Reversed() {
     m_nTimeTillWeNeedThisCar = CTimer::GetTimeInMS() + 3000;
     if (CCheat::m_aCheatsActive[eCheats::CHEAT_INVISIBLE_CAR])
         return;
@@ -892,8 +810,7 @@ void CBoat::Render_Reversed()
     RwRenderStateSet(rwRENDERSTATEDESTBLEND, RWRSTATE(rwBLENDINVSRCALPHA));
 }
 
-void CBoat::ProcessControlInputs_Reversed(uint8 ucPadNum)
-{
+void CBoat::ProcessControlInputs_Reversed(uint8 ucPadNum) {
     m_nPadNumber = ucPadNum;
     if (ucPadNum > 3)
         m_nPadNumber = 3;
@@ -916,8 +833,7 @@ void CBoat::ProcessControlInputs_Reversed(uint8 ucPadNum)
         if (CPad::NewMouseControllerState.X == 0.0F && bChangedInput) { // No longer using mouse controls
             m_fRawSteerAngle += (static_cast<float>(-pad->GetSteeringLeftRight()) * (1.0F / 128.0F) - m_fRawSteerAngle) * 0.2F * CTimer::GetTimeStep();
             CVehicle::m_nLastControlInput = eControllerType::CONTROLLER_KEYBOARD1;
-        }
-        else if (m_fRawSteerAngle != 0.0F || m_fRawSteerAngle != 0.0F) {
+        } else if (m_fRawSteerAngle != 0.0F || m_fRawSteerAngle != 0.0F) {
             CVehicle::m_nLastControlInput = eControllerType::CONTROLLER_MOUSE;
             if (!pad->NewState.m_bVehicleMouseLook)
                 m_fRawSteerAngle += CPad::NewMouseControllerState.X * -0.0035F;
@@ -925,8 +841,7 @@ void CBoat::ProcessControlInputs_Reversed(uint8 ucPadNum)
             if (fabs(m_fRawSteerAngle) < 0.5 || pad->NewState.m_bVehicleMouseLook)
                 m_fRawSteerAngle *= pow(0.985F, CTimer::GetTimeStep());
         }
-    }
-    else {
+    } else {
         m_fRawSteerAngle += (static_cast<float>(-pad->GetSteeringLeftRight()) * (1.0F / 128.0F) - m_fRawSteerAngle) * 0.2F * CTimer::GetTimeStep();
         CVehicle::m_nLastControlInput = eControllerType::CONTROLLER_KEYBOARD1;
     }
@@ -936,18 +851,15 @@ void CBoat::ProcessControlInputs_Reversed(uint8 ucPadNum)
     m_fSteerAngle = DegreesToRadians(m_pHandlingData->m_fSteeringLock * fSignedPow);
 }
 
-void CBoat::GetComponentWorldPosition_Reversed(int32 componentId, CVector& outPos)
-{
+void CBoat::GetComponentWorldPosition_Reversed(int32 componentId, CVector& outPos) {
     outPos = RwFrameGetLTM(m_aBoatNodes[componentId])->pos;
 }
 
-void CBoat::ProcessOpenDoor_Reversed(CPed* ped, uint32 doorComponentId, uint32 arg2, uint32 arg3, float arg4)
-{
-    return;
+void CBoat::ProcessOpenDoor_Reversed(CPed* ped, uint32 doorComponentId, uint32 animGroup, uint32 animId, float fTime) {
+    // NOP
 }
 
-void CBoat::BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion)
-{
+void CBoat::BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion) {
     if (!vehicleFlags.bCanBeDamaged)
         return;
 
@@ -1023,10 +935,19 @@ void CBoat::BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion)
         RpAtomicSetFlags(movingCompAtomic, 0x0);
 }
 
-RwObject* GetBoatAtomicObjectCB(RwObject* object, void* data)
-{
+RwObject* GetBoatAtomicObjectCB(RwObject* object, void* data) {
     if (RpAtomicGetFlags(object) & rpATOMICRENDER)
         *static_cast<RpAtomic**>(data) = reinterpret_cast<RpAtomic*>(object);
 
     return object;
 }
+
+void CBoat::SetModelIndex(uint32 index) { return CBoat::SetModelIndex_Reversed(index); }
+void CBoat::ProcessControl() { return CBoat::ProcessControl_Reversed(); }
+void CBoat::Teleport(CVector destination, bool resetRotation) { return CBoat::Teleport_Reversed(destination, resetRotation); }
+void CBoat::PreRender() { return CBoat::PreRender_Reversed(); }
+void CBoat::Render() { return CBoat::Render_Reversed(); }
+void CBoat::ProcessControlInputs(uint8 playerNum) { return CBoat::ProcessControlInputs_Reversed(playerNum); }
+void CBoat::GetComponentWorldPosition(int32 componentId, CVector& outPos) { return CBoat::GetComponentWorldPosition_Reversed(componentId, outPos); }
+void CBoat::ProcessOpenDoor(CPed* ped, uint32 doorComponentId, uint32 animGroup, uint32 animId, float fTime) { return CBoat::ProcessOpenDoor_Reversed(ped, doorComponentId, animGroup, animId, fTime); }
+void CBoat::BlowUpCar(CEntity* damager, uint8 bHideExplosion) { return CBoat::BlowUpCar_Reversed(damager, bHideExplosion); }

--- a/source/game_sa/Entity/Vehicle/Boat.h
+++ b/source/game_sa/Entity/Vehicle/Boat.h
@@ -11,25 +11,23 @@
 #include "tBoatHandlingData.h"
 
 enum eBoatNodes {
-    BOAT_NODE_NONE = 0,
-    BOAT_MOVING = 1,
-    BOAT_WINDSCREEN = 2,
-    BOAT_RUDDER = 3,
-    BOAT_FLAP_LEFT = 4,
-    BOAT_FLAP_RIGHT = 5,
-    BOAT_REARFLAP_LEFT = 6,
+    BOAT_NODE_NONE      = 0,
+    BOAT_MOVING         = 1,
+    BOAT_WINDSCREEN     = 2,
+    BOAT_RUDDER         = 3,
+    BOAT_FLAP_LEFT      = 4,
+    BOAT_FLAP_RIGHT     = 5,
+    BOAT_REARFLAP_LEFT  = 6,
     BOAT_REARFLAP_RIGHT = 7,
-    BOAT_STATIC_PROP = 8,
-    BOAT_MOVING_PROP = 9,
-    BOAT_STATIC_PROP_2 = 10,
-    BOAT_MOVING_PROP_2 = 11,
+    BOAT_STATIC_PROP    = 8,
+    BOAT_MOVING_PROP    = 9,
+    BOAT_STATIC_PROP_2  = 10,
+    BOAT_MOVING_PROP_2  = 11,
+
     BOAT_NUM_NODES
 };
 
 class CBoat : public CVehicle {
-public:
-    CBoat(int32 modelIndex, eVehicleCreatedBy createdBy);
-    ~CBoat() override;
 public:
     float m_fMovingHiRotation; // works as counter also
     float m_fPropSpeed;        // propeller speed
@@ -39,7 +37,6 @@ public:
         uint8 bMovingOnWater : 1;
         uint8 bAnchored : 1; // is anchored
     } m_nBoatFlags;
-    char               _pad5AD[3];
     RwFrame*           m_aBoatNodes[BOAT_NUM_NODES];
     CDoor              m_boatFlap; // for marquis model
     tBoatHandlingData* m_pBoatHandling;
@@ -54,36 +51,34 @@ public:
     CVector            m_vecWaterDamping; // { 0.0f, 0.0f, DampingPower }
     char               field_63C;         // initialised with 0, maybe boat handling type (@CBoat::DebugCode), possibly a leftover
     uint8              m_nPadNumber;      // 0 - 3
-    char               _pad63E[2];
     float              m_fLastWaterImmersionDepth; // initialised with 7.0f, 0.0f - not in water
     int16              m_nNumWaterTrailPoints;
-    char               _pad646[2];
     CVector2D          m_avecWakePoints[32];
     float              m_afWakePointLifeTime[32];
     uint8              m_anWakePointIntensity[32]; // m_anWakePointIntensity[i] = boat->m_vecMoveForce.Magnitude() * 100.0f;
 
     static constexpr int32 NUM_WAKE_GEN_BOATS = 4;
-    static CBoat*(&apFrameWakeGeneratingBoats)[NUM_WAKE_GEN_BOATS]; // static CBoat *apFrameWakeGeneratingBoats[4]
-    static float& MAX_WAKE_LENGTH; // 50.0
-    static float& MIN_WAKE_INTERVAL; // 2.0
-    static float& WAKE_LIFETIME; // 150.0
-    static float& fShapeLength; // 0.4
-    static float& fShapeTime; // 0.05
-    static float& fRangeMult; // 0.6
+    static CBoat* (&apFrameWakeGeneratingBoats)[NUM_WAKE_GEN_BOATS];
+    static float& MAX_WAKE_LENGTH;
+    static float& MIN_WAKE_INTERVAL;
+    static float& WAKE_LIFETIME;
+    static float& fShapeLength;
+    static float& fShapeTime;
+    static float& fRangeMult;
 
-    static int16* waUnknArr;  // static CBoat::waUnknArr[4]
-    static int16* waUnknArr2; // static CBoat::waUnknArr2[4]
+    static int16 (&waUnknArr)[4];
+    static int16 (&waUnknArr2)[4];
 
-    static const constexpr uint32 uiNumVertices = 4;
+    static const constexpr auto uiNumVertices{ 4u };
     static RxObjSpace3DVertex* aRenderVertices;
 
-    static const constexpr uint32 uiNumIndices = 6;
+    static const constexpr auto uiNumIndices{ 6u };
     static RxVertexIndex* auRenderIndices;
 
 public:
-    static void InjectHooks();
+    CBoat(int32 modelIndex, eVehicleCreatedBy createdBy);
+    ~CBoat() override;
 
-    // Virtual methods
     void SetModelIndex(uint32 index) override;
     void ProcessControl() override;
     void Teleport(CVector destination, bool resetRotation) override;
@@ -91,22 +86,25 @@ public:
     void Render() override;
     void ProcessControlInputs(uint8 playerNum) override;
     void GetComponentWorldPosition(int32 componentId, CVector& outPos) override;
-    void ProcessOpenDoor(CPed* ped, uint32 doorComponentId, uint32 animGroup, uint32 arg3, float arg4) override;
+    void ProcessOpenDoor(CPed* ped, uint32 doorComponentId, uint32 animGroup, uint32 animId, float fTime) override;
     void BlowUpCar(CEntity* damager, uint8 bHideExplosion) override;
 
     inline void SetupModelNodes(); // fill m_aBoatNodes array
     void DebugCode();
-    void PrintThrustAndRudderInfo(); // uses debug printing
+    void PrintThrustAndRudderInfo();
     void ModifyHandlingValue(const bool& bIncrement);
     void PruneWakeTrail();
     void AddWakePoint(CVector posn);
 
     static bool IsSectorAffectedByWake(CVector2D vecPos, float fOffset, CBoat** ppBoats);
-    static float IsVertexAffectedByWake(CVector vecPos, CBoat* pBoat, int16 wIndex, bool bUnkn);
+    static float IsVertexAffectedByWake(CVector vecPos, CBoat* boat, int16 wIndex, bool bUnkn);
     static void CheckForSkippingCalculations();
     static void FillBoatList();
 
 private:
+    friend void InjectHooksMain();
+    static void InjectHooks();
+
     void SetModelIndex_Reversed(uint32 index);
     void ProcessControl_Reversed();
     void Teleport_Reversed(CVector destination, bool resetRotation);

--- a/source/game_sa/Entity/Vehicle/Heli.cpp
+++ b/source/game_sa/Entity/Vehicle/Heli.cpp
@@ -15,7 +15,7 @@ tHeliLight (&CHeli::HeliSearchLights)[4] = *(tHeliLight(*)[4])0xC1C990;
 
 void CHeli::InjectHooks() {
     RH_ScopedClass(CHeli);
-    RH_ScopedCategory("Vehicle/Ped");
+    RH_ScopedCategory("Vehicle");
 
     RH_ScopedInstall(InitHelis, 0x6C4560);
     RH_ScopedInstall(AddHeliSearchLight, 0x6C45B0);
@@ -31,7 +31,7 @@ void CHeli::InjectHooks() {
 }
 
 // 0x6C4190
-CHeli::CHeli(int32 modelIndex, eVehicleCreatedBy createdBy) : CAutomobile(modelIndex, createdBy, true) {
+CHeli::CHeli(int32 modelIndex, eVehicleCreatedBy createdBy) : CAutomobile({}) {
     plugin::CallMethod<0x6C4190, CHeli*, int32, eVehicleCreatedBy>(this, modelIndex, createdBy);
 }
 

--- a/source/game_sa/Entity/Vehicle/Heli.cpp
+++ b/source/game_sa/Entity/Vehicle/Heli.cpp
@@ -8,31 +8,75 @@
 
 bool& CHeli::bPoliceHelisAllowed = *(bool*)0x8D338C;
 uint32& CHeli::TestForNewRandomHelisTimer = *(uint32*)0xC1C960;
-CHeli** CHeli::pHelis = (CHeli**)0xC1C964;
+CHeli* (&CHeli::pHelis)[2] = *(CHeli*(*)[2])0xC1C964;
 uint32& CHeli::NumberOfSearchLights = *(uint32*)0xC1C96C;
 bool& CHeli::bHeliControlsCheat = *(bool*)0xC1C970;
-tHeliLight* CHeli::HeliSearchLights = (tHeliLight*)0xC1C990;
+tHeliLight (&CHeli::HeliSearchLights)[4] = *(tHeliLight(*)[4])0xC1C990;
 
 void CHeli::InjectHooks() {
     RH_ScopedClass(CHeli);
     RH_ScopedCategory("Vehicle/Ped");
 
-
+    RH_ScopedInstall(InitHelis, 0x6C4560);
+    RH_ScopedInstall(AddHeliSearchLight, 0x6C45B0);
+    RH_ScopedInstall(Pre_SearchLightCone, 0x6C4650);
+    RH_ScopedInstall(Post_SearchLightCone, 0x6C46E0);
+    RH_ScopedInstall(SwitchPoliceHelis, 0x6C4800);
+    RH_ScopedInstall(RenderAllHeliSearchLights, 0x6C7C50);
+    RH_ScopedInstall(TestSniperCollision, 0x6C6890);
+    RH_ScopedInstall(Render_Reversed, 0x6C4400);
+    RH_ScopedInstall(Fix_Reversed, 0x6C4530);
+    RH_ScopedInstall(BurstTyre_Reversed, 0x6C4330);
+    RH_ScopedInstall(SetUpWheelColModel_Reversed, 0x6C4320);
 }
 
 // 0x6C4190
-CHeli::CHeli(int32 modelIndex, eVehicleCreatedBy createdBy) : CAutomobile(plugin::dummy) {
+CHeli::CHeli(int32 modelIndex, eVehicleCreatedBy createdBy) : CAutomobile(modelIndex, createdBy, true) {
     plugin::CallMethod<0x6C4190, CHeli*, int32, eVehicleCreatedBy>(this, modelIndex, createdBy);
+}
+
+// 0x6C4340
+CHeli::~CHeli() {
+    if (m_ppGunflashFx) {
+        for (auto i = 0; i < CVehicle::GetPlaneNumGuns(); i++) {
+            auto& fx = m_ppGunflashFx[i];
+            if (fx) {
+                fx->Kill();
+                g_fxMan.DestroyFxSystem(fx);
+            }
+        }
+        delete[] m_ppGunflashFx;
+        m_ppGunflashFx = nullptr;
+    }
+
+    m_vehicleAudio.Terminate();
 }
 
 // 0x6C4560
 void CHeli::InitHelis() {
-    ((void(__cdecl*)())0x6C4560)();
+    std::ranges::fill(pHelis, nullptr);
+    for (auto& light : HeliSearchLights) {
+        light.Init();
+    }
+    NumberOfSearchLights = 0;
+    bPoliceHelisAllowed = true;
 }
 
 // 0x6C45B0
 void CHeli::AddHeliSearchLight(const CVector& origin, const CVector& target, float targetRadius, float power, uint32 coronaIndex, uint8 unknownFlag, uint8 drawShadow) {
-    ((void(__cdecl*)(const CVector&, const CVector&, float, float, uint32, uint8, uint8))0x6C45B0)(origin, target, targetRadius, power, coronaIndex, unknownFlag, drawShadow);
+    // return ((void(__cdecl*)(const CVector&, const CVector&, float, float, uint32, uint8, uint8))0x6C45B0)(origin, target, targetRadius, power, coronaIndex, unknownFlag, drawShadow);
+
+    auto& light = HeliSearchLights[NumberOfSearchLights];
+
+    light.m_vecOrigin     = origin;
+    light.m_vecTarget     = target;
+    light.m_fTargetRadius = targetRadius;
+    light.m_fPower        = power;
+    light.m_nCoronaIndex  = coronaIndex;
+    light.field_24        = unknownFlag;
+    light.m_bDrawShadow   = drawShadow;
+
+    NumberOfSearchLights += 1;
 }
 
 // 0x6C4640
@@ -42,12 +86,28 @@ void CHeli::PreRenderAlways() {
 
 // 0x6C4650
 void CHeli::Pre_SearchLightCone() {
-    ((void(__cdecl*)())0x6C4650)();
+    RwRenderStateSet(rwRENDERSTATEZWRITEENABLE,         RWRSTATE(FALSE));
+    RwRenderStateSet(rwRENDERSTATEZTESTENABLE,          RWRSTATE(TRUE));
+    RwRenderStateSet(rwRENDERSTATESRCBLEND,             RWRSTATE(rwBLENDONE));
+    RwRenderStateSet(rwRENDERSTATEDESTBLEND,            RWRSTATE(rwBLENDONE));
+    RwRenderStateSet(rwRENDERSTATEVERTEXALPHAENABLE,    RWRSTATE(TRUE));
+    RwRenderStateSet(rwRENDERSTATETEXTURERASTER,        RWRSTATE(NULL));
+    RwRenderStateSet(rwRENDERSTATEFOGENABLE,            RWRSTATE(FALSE));
+    RwRenderStateSet(rwRENDERSTATESHADEMODE,            RWRSTATE(rwSHADEMODEGOURAUD));
+    RwRenderStateSet(rwRENDERSTATEALPHATESTFUNCTION,    RWRSTATE(rwALPHATESTFUNCTIONGREATEREQUAL));
+    RwRenderStateSet(rwRENDERSTATEALPHATESTFUNCTIONREF, RWRSTATE(0));
 }
 
 // 0x6C46E0
 void CHeli::Post_SearchLightCone() {
-    ((void(__cdecl*)())0x6C46E0)();
+    RwRenderStateSet(rwRENDERSTATEZWRITEENABLE,         RWRSTATE(TRUE));
+    RwRenderStateSet(rwRENDERSTATEZTESTENABLE,          RWRSTATE(TRUE));
+    RwRenderStateSet(rwRENDERSTATESRCBLEND,             RWRSTATE(rwBLENDSRCALPHA));
+    RwRenderStateSet(rwRENDERSTATEDESTBLEND,            RWRSTATE(rwBLENDINVSRCALPHA));
+    RwRenderStateSet(rwRENDERSTATEVERTEXALPHAENABLE,    RWRSTATE(FALSE));
+    RwRenderStateSet(rwRENDERSTATECULLMODE,             RWRSTATE(rwCULLMODECULLBACK));
+    RwRenderStateSet(rwRENDERSTATEALPHATESTFUNCTION,    RWRSTATE(rwALPHATESTFUNCTIONGREATER));
+    RwRenderStateSet(rwRENDERSTATEALPHATESTFUNCTIONREF, RWRSTATE(2u));
 }
 
 // 0x6C4750
@@ -60,6 +120,19 @@ CVector CHeli::FindSwatPositionRelativeToHeli(int32 swatNumber) {
     CVector result;
     ((void(__thiscall*)(CHeli*, CVector*, int32))0x6C4760)(this, &result, swatNumber);
     return result;
+
+    switch ( swatNumber ) {
+    case 0:
+        return { -1.2f, -1.0f, -0.5f };
+    case 1:
+        return { 1.2f,  -1.0f, -0.5f };
+    case 2:
+        return { -1.2f, 1.0f,  -0.5f };
+    case 3:
+        return { 1.2f,  1.0f,  -0.5f };
+    default:
+        return { 0.0f,  0.0f,  0.0f  };
+    }
 }
 
 // 0x6C4800
@@ -68,8 +141,15 @@ void CHeli::SwitchPoliceHelis(bool enable) {
 }
 
 // 0x6C58E0
-void CHeli::SearchLightCone(int32 coronaIndex, CVector origin, CVector target, float targetRadius, float power, uint8 unknownFlag, uint8 drawShadow, CVector* arg7, CVector* arg8, CVector* arg9, bool arg10, float baseRadius) {
-    ((void(__cdecl*)(int32, CVector, CVector, float, float, uint8, uint8, CVector*, CVector*, CVector*, bool, float))0x6C58E0)(coronaIndex, origin, target, targetRadius, power, unknownFlag, drawShadow, arg7, arg8, arg9, arg10, baseRadius);
+void CHeli::SearchLightCone(int32 coronaIndex,
+                            CVector origin, CVector target,
+                            float targetRadius,
+                            float power,
+                            uint8 unknownFlag, uint8 drawShadow,
+                            CVector* useless0, CVector* useless1, CVector* useless2,
+                            bool a11, float baseRadius, float a13,float a14,float a15
+) {
+    ((void(__cdecl*)(int32, CVector, CVector, float, float, uint8, uint8, CVector*, CVector*, CVector*, bool, float, float, float, float))0x6C58E0)(coronaIndex, origin, target, targetRadius, power, unknownFlag, drawShadow, useless0, useless1, useless2, a11, baseRadius, a13, a14, a15);
 }
 
 // 0x6C6520
@@ -78,8 +158,24 @@ CHeli* CHeli::GenerateHeli(CPed* target, bool newsHeli) {
 }
 
 // 0x6C6890
-bool CHeli::TestSniperCollision(CVector* origin, CVector* target) {
-    return ((bool(__cdecl*)(CVector*, CVector*))0x6C6890)(origin, target);
+void CHeli::TestSniperCollision(CVector* origin, CVector* target) {
+    CVector point = *target - *origin;
+
+    if (point.z >= point.Magnitude() / 2.0f)
+        return;
+
+    for (auto& heli : pHelis) {
+        if (!heli || heli->physicalFlags.bBulletProof)
+            continue;
+
+        const auto mat = (CMatrix*)heli->m_matrix;
+        auto out = MultiplyMatrixWithVector(*mat, { -0.43f, 1.49f, 1.5f });
+        if (CCollision::DistToLine(origin, target, &out) < 0.8f) {
+            heli->m_fRotationBalance = (float)(rand() < pow(2, 14) - 1) * 0.1f - 0.05f; // 2^14 - 1 = 16383
+            heli->BlowUpCar(FindPlayerPed(), false);
+            heli->m_nNumSwatOccupants = 0;
+        };
+    }
 }
 
 // 0x6C69C0
@@ -94,23 +190,110 @@ void CHeli::UpdateHelis() {
 
 // 0x6C7C50
 void CHeli::RenderAllHeliSearchLights() {
-    ((void(__cdecl*)())0x6C7C50)();
+    for (auto& light : HeliSearchLights) {
+        SearchLightCone(
+            light.m_nCoronaIndex,
+            light.m_vecOrigin,
+            light.m_vecTarget,
+            light.m_fTargetRadius,
+            light.m_fPower,
+            light.field_24,
+            light.m_bDrawShadow,
+            light.m_vecUseless,
+            &light.m_vecUseless[1],
+            &light.m_vecUseless[2],
+            false,
+            0.05f,
+            0.0f,
+            0.0f,
+            1.0f
+        );
+    }
 }
 
 // 0x6C6D30
 void CHeli::BlowUpCar(CEntity* damager, uint8 bHideExplosion) {
-    return BlowUpCar_Reversed(damager, bHideExplosion);
-}
-
-void CHeli::BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion) {
     plugin::CallMethod<0x6C6D30, CHeli*, CEntity*, uint8>(this, damager, bHideExplosion);
 }
 
 // 0x6C4530
 void CHeli::Fix() {
-    Fix_Reversed();
+    m_damageManager.ResetDamageStatus();
+    SetupDamageAfterLoad();
 }
 
-void CHeli::Fix_Reversed() {
-    plugin::CallMethod<0x6C4530, CHeli*>(this);
+// 0x6C4330
+bool CHeli::BurstTyre(uint8 tyreComponentId, bool bPhysicalEffect) {
+    return false;
+}
+
+// 0x6C4320
+bool CHeli::SetUpWheelColModel(CColModel* wheelCol) {
+    return false;
+}
+
+// 0x6C4830
+void CHeli::ProcessControlInputs(uint8 playerNum) {
+    plugin::CallMethod<0x6C4830, CHeli*, uint8>(this, playerNum);
+}
+
+// 0x6C4400
+void CHeli::Render() {
+    auto mi = CModelInfo::GetModelInfo(m_nModelIndex);
+    m_nTimeTillWeNeedThisCar = CTimer::GetTimeInMS() + 3000;
+    mi->AsVehicleModelInfoPtr()->SetVehicleColour(m_nPrimaryColor, m_nSecondaryColor, m_nTertiaryColor, m_nQuaternaryColor);
+
+    auto staticRotor = m_aCarNodes[HELI_STATIC_ROTOR];
+    RpAtomic* data = nullptr;
+    if (staticRotor) {
+        RwFrameForAllObjects(staticRotor, GetCurrentAtomicObjectCB, &data);
+        if (data)
+            CVehicle::SetComponentAtomicAlpha(data, 255);
+    }
+
+    auto staticRotor2 = m_aCarNodes[HELI_STATIC_ROTOR2];
+    data = nullptr;
+    if (staticRotor2) {
+        RwFrameForAllObjects(staticRotor2, GetCurrentAtomicObjectCB, &data);
+        if (data)
+            CVehicle::SetComponentAtomicAlpha(data, 255);
+    }
+
+    auto movingRotor = m_aCarNodes[HELI_MOVING_ROTOR];
+    data = nullptr;
+    if (movingRotor) {
+        RwFrameForAllObjects(movingRotor, GetCurrentAtomicObjectCB, &data);
+        if (data)
+            CVehicle::SetComponentAtomicAlpha(data, 0);
+    }
+
+    auto movingRotor2 = m_aCarNodes[HELI_MOVING_ROTOR2];
+    data = nullptr;
+    if (movingRotor2) {
+        RwFrameForAllObjects(movingRotor2, GetCurrentAtomicObjectCB, &data);
+        if (data)
+            CVehicle::SetComponentAtomicAlpha(data, 0);
+    }
+
+    CEntity::Render(); // exactly CEntity
+}
+
+// 0x6C4550
+void CHeli::SetupDamageAfterLoad() {
+    vehicleFlags.bIsDamaged = false;
+}
+
+// 0x6C4E60
+void CHeli::ProcessFlyingCarStuff() {
+    plugin::CallMethod<0x6C4E60, CHeli*>(this);
+}
+
+// 0x6C5420
+void CHeli::PreRender() {
+    plugin::CallMethod<0x6C5420, CHeli*>(this);
+}
+
+// 0x6C7050
+void CHeli::ProcessControl() {
+    plugin::CallMethod<0x6C7050, CHeli*>(this);
 }

--- a/source/game_sa/Entity/Vehicle/Heli.h
+++ b/source/game_sa/Entity/Vehicle/Heli.h
@@ -43,7 +43,7 @@ struct tHeliLight {
     uint32  m_nCoronaIndex;
     bool    field_24; // unknown flag
     bool    m_bDrawShadow;
-    CVector m_vecUseless[3];
+    CVector m_vecUseless[3]; // m_aSearchLightHistory
 
     void Init() {
         m_vecOrigin = CVector{};
@@ -59,7 +59,7 @@ class FxSystem_c;
 
 class CHeli : public CAutomobile {
 public:
-    char         m_nHeliFlags;
+    uint8        m_nHeliFlags;
     float        m_fLeftRightSkid;
     float        m_fSteeringUpDown;
     float        m_fSteeringLeftRight;
@@ -72,19 +72,21 @@ public:
     float        m_fMinAltitude;
     int32        field_9B4;
     char         field_9B8;
-    char         m_nNumSwatOccupants;
-    char         m_anSwatIDs[4];
-    int32        field_9C0[4];
-    int32        field_9D0;
+    int8         m_nNumSwatOccupants;
+    uint8        m_aSwatState[4];
+    CVector      field_9C0;
+    int          f9CC;
+    int          f9D0;
     FxSystem_c** m_pParticlesList;
-    char         field_9D8[24];
-    int32        field_9F0;
+    float        m_aSearchLightHistoryX[3];
+    float        m_aSearchLightHistoryY[3];
+    uint32       m_nSearchLightTimer;
     CVector      m_vecSearchLightTarget;
     float        m_fSearchLightIntensity;
-    int32        field_A04;
-    int32        field_A08;
+    uint32       m_nShootTimer;
+    uint32       m_nPoliceShoutTimer;
     FxSystem_c** m_ppGunflashFx;
-    char         m_nFiringMultiplier;
+    int8         m_nFiringMultiplier;
     bool         m_bSearchLightEnabled;
     float        field_A14;
 

--- a/source/game_sa/Entity/Vehicle/Heli.h
+++ b/source/game_sa/Entity/Vehicle/Heli.h
@@ -9,28 +9,29 @@
 #include "Automobile.h"
 
 enum eHeliNodes {
-    HELI_NODE_NONE = 0,
-    HELI_CHASSIS = 1,
-    HELI_WHEEL_RF = 2,
-    HELI_WHEEL_RM = 3,
-    HELI_WHEEL_RB = 4,
-    HELI_WHEEL_LF = 5,
-    HELI_WHEEL_LM = 6,
-    HELI_WHEEL_LB = 7,
-    HELI_DOOR_RF = 8,
-    HELI_DOOR_RR = 9,
-    HELI_DOOR_LF = 10,
-    HELI_DOOR_LR = 11,
-    HELI_STATIC_ROTOR = 12,
-    HELI_MOVING_ROTOR = 13,
+    HELI_NODE_NONE     = 0,
+    HELI_CHASSIS       = 1,
+    HELI_WHEEL_RF      = 2,
+    HELI_WHEEL_RM      = 3,
+    HELI_WHEEL_RB      = 4,
+    HELI_WHEEL_LF      = 5,
+    HELI_WHEEL_LM      = 6,
+    HELI_WHEEL_LB      = 7,
+    HELI_DOOR_RF       = 8,
+    HELI_DOOR_RR       = 9,
+    HELI_DOOR_LF       = 10,
+    HELI_DOOR_LR       = 11,
+    HELI_STATIC_ROTOR  = 12,
+    HELI_MOVING_ROTOR  = 13,
     HELI_STATIC_ROTOR2 = 14,
     HELI_MOVING_ROTOR2 = 15,
-    HELI_RUDDER = 16,
-    HELI_ELEVATORS = 17,
-    HELI_MISC_A = 18,
-    HELI_MISC_B = 19,
-    HELI_MISC_C = 20,
-    HELI_MISC_D = 21,
+    HELI_RUDDER        = 16,
+    HELI_ELEVATORS     = 17,
+    HELI_MISC_A        = 18,
+    HELI_MISC_B        = 19,
+    HELI_MISC_C        = 20,
+    HELI_MISC_D        = 21,
+
     HELI_NUM_NODES
 };
 
@@ -39,11 +40,17 @@ struct tHeliLight {
     CVector m_vecTarget;
     float   m_fTargetRadius;
     float   m_fPower;
-    int32   m_nCoronaIndex;
+    uint32  m_nCoronaIndex;
     bool    field_24; // unknown flag
     bool    m_bDrawShadow;
-    char    _pad[2];
-    CVector field_28[3];
+    CVector m_vecUseless[3];
+
+    void Init() {
+        m_vecOrigin = CVector{};
+        m_vecTarget = CVector{};
+        m_fTargetRadius = 0.0f;
+        m_fPower = 0.0f;
+    }
 };
 
 VALIDATE_SIZE(tHeliLight, 0x4C);
@@ -51,11 +58,8 @@ VALIDATE_SIZE(tHeliLight, 0x4C);
 class FxSystem_c;
 
 class CHeli : public CAutomobile {
-protected:
-    CHeli(plugin::dummy_func_t) : CAutomobile(plugin::dummy) {}
 public:
     char         m_nHeliFlags;
-    char         _pad1[3];
     float        m_fLeftRightSkid;
     float        m_fSteeringUpDown;
     float        m_fSteeringLeftRight;
@@ -70,7 +74,6 @@ public:
     char         field_9B8;
     char         m_nNumSwatOccupants;
     char         m_anSwatIDs[4];
-    char         _pad2[2];
     int32        field_9C0[4];
     int32        field_9D0;
     FxSystem_c** m_pParticlesList;
@@ -83,23 +86,30 @@ public:
     FxSystem_c** m_ppGunflashFx;
     char         m_nFiringMultiplier;
     bool         m_bSearchLightEnabled;
-    char         _pad3[2];
     float        field_A14;
 
     static bool& bPoliceHelisAllowed; // 1
     static uint32& TestForNewRandomHelisTimer;
-    static CHeli** pHelis; // CHeli* pHelis[2];
+    static CHeli* (&pHelis)[2];
     static uint32& NumberOfSearchLights;
     static bool& bHeliControlsCheat;
-    static tHeliLight* HeliSearchLights; // tHeliLight CHeli::HeliSearchLights[4]
+    static tHeliLight (&HeliSearchLights)[4];
 
 public:
-    static void InjectHooks();
-
+    CHeli(plugin::dummy_func_t) : CAutomobile(plugin::dummy) { /* todo: remove NOTSA */ }
     CHeli(int32 modelIndex, eVehicleCreatedBy createdBy);
+    ~CHeli() override; // 0x6C4340, 0x6C4810
 
     void BlowUpCar(CEntity* damager, uint8 bHideExplosion) override;
     void Fix() override;
+    bool BurstTyre(uint8 tyreComponentId, bool bPhysicalEffect) override;
+    bool SetUpWheelColModel(CColModel* wheelCol) override;
+    void ProcessControlInputs(uint8 playerNum) override;
+    void Render() override;
+    void SetupDamageAfterLoad() override;
+    void ProcessFlyingCarStuff() override;
+    void PreRender() override;
+    void ProcessControl() override;
 
     void PreRenderAlways();
     CVector FindSwatPositionRelativeToHeli(int32 swatNumber);
@@ -113,15 +123,32 @@ public:
     static void Post_SearchLightCone();
     static void SpecialHeliPreRender(); // dummy function
     static void SwitchPoliceHelis(bool enable);
-    static void SearchLightCone(int32 coronaIndex, CVector origin, CVector target, float targetRadius, float power, uint8 unknownFlag, uint8 drawShadow, CVector* arg7, CVector* arg8, CVector* arg9, bool arg10, float baseRadius);
+    static void SearchLightCone(int32 coronaIndex,
+                                CVector origin, CVector target,
+                                float targetRadius,
+                                float power,
+                                uint8 unknownFlag, uint8 drawShadow,
+                                CVector* useless0, CVector* useless1, CVector* useless2,
+                                bool a11, float baseRadius, float a13, float a14, float a15);
     static CHeli* GenerateHeli(CPed* target, bool newsHeli);
-    static bool TestSniperCollision(CVector* origin, CVector* target);
+    static void TestSniperCollision(CVector* origin, CVector* target);
     static void UpdateHelis();
     static void RenderAllHeliSearchLights();
 
 private:
-    void BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion);
-    void Fix_Reversed();
+    friend void InjectHooksMain();
+    static void InjectHooks();
+
+    void BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion) { return CHeli::BlowUpCar(damager, bHideExplosion); }
+    void Fix_Reversed() { CHeli::Fix(); }
+    bool BurstTyre_Reversed(uint8 tyreComponentId, bool bPhysicalEffect) { return CHeli::BurstTyre(tyreComponentId, bPhysicalEffect); }
+    bool SetUpWheelColModel_Reversed(CColModel* wheelCol) { return CHeli::SetUpWheelColModel(wheelCol); }
+    void ProcessControlInputs_Reversed(uint8 playerNum) { return CHeli::ProcessControlInputs(playerNum); }
+    void Render_Reversed() { CHeli::Render(); }
+    void SetupDamageAfterLoad_Reversed() { CHeli::SetupDamageAfterLoad(); }
+    void ProcessFlyingCarStuff_Reversed() { CHeli::ProcessFlyingCarStuff(); }
+    void PreRender_Reversed() { CHeli::PreRender(); }
+    void ProcessControl_Reversed() { CHeli::ProcessControl(); }
 };
 
 VALIDATE_SIZE(CHeli, 0xA18);

--- a/source/game_sa/Entity/Vehicle/Heli.h
+++ b/source/game_sa/Entity/Vehicle/Heli.h
@@ -70,13 +70,13 @@ public:
     float        m_fMaxAltitude;
     float        field_9AC;
     float        m_fMinAltitude;
-    int32        field_9B4;
+    float        field_9B4; // m_fHeading related
     char         field_9B8;
     int8         m_nNumSwatOccupants;
     uint8        m_aSwatState[4];
     CVector      field_9C0;
-    int          f9CC;
-    int          f9D0;
+    int32        f9CC; // unused?
+    int32        f9D0; // unused?
     FxSystem_c** m_pParticlesList;
     float        m_aSearchLightHistoryX[3];
     float        m_aSearchLightHistoryY[3];

--- a/source/game_sa/Entity/Vehicle/MonsterTruck.cpp
+++ b/source/game_sa/Entity/Vehicle/MonsterTruck.cpp
@@ -7,7 +7,7 @@ float& fWheelExtensionRate = *(float*)0x8D33AC;
 
 void CMonsterTruck::InjectHooks() {
     RH_ScopedClass(CMonsterTruck);
-    RH_ScopedCategory("Vehicle/Ped");
+    RH_ScopedCategory("Vehicle");
 
     // RH_ScopedInstall(ProcessEntityCollision, 0x6C8AE0);
     // RH_ScopedInstall(ProcessSuspension, 0x6C83A0);

--- a/source/game_sa/Entity/Vehicle/MonsterTruck.cpp
+++ b/source/game_sa/Entity/Vehicle/MonsterTruck.cpp
@@ -1,12 +1,83 @@
 #include "StdInc.h"
 
+#include "MonsterTruck.h"
+
 float& CMonsterTruck::DUMPER_COL_ANGLEMULT = *(float*)0x8D33A8;
 float& fWheelExtensionRate = *(float*)0x8D33AC;
 
-CMonsterTruck::CMonsterTruck(int32 modelIndex, eVehicleCreatedBy createdBy) : CAutomobile(plugin::dummy) {
-    plugin::CallMethod<0x6C8D60, CMonsterTruck*, int32, eVehicleCreatedBy>(this, modelIndex, createdBy);
+void CMonsterTruck::InjectHooks() {
+    RH_ScopedClass(CMonsterTruck);
+    RH_ScopedCategory("Vehicle/Ped");
+
+    // RH_ScopedInstall(ProcessEntityCollision, 0x6C8AE0);
+    // RH_ScopedInstall(ProcessSuspension, 0x6C83A0);
+    // RH_ScopedInstall(ProcessControlCollisionCheck, 0x6C8330);
+    // RH_ScopedInstall(ProcessControl, 0x6C8250);
+    // RH_ScopedInstall(SetupSuspensionLines, 0x6C7FB0);
+    // RH_ScopedInstall(PreRender, 0x6C7DE0);
+    // RH_ScopedInstall(ExtendSuspension, 0x6C7D80);
+    // RH_ScopedInstall(ResetSuspension, 0x6C7D40);
+    RH_ScopedInstall(BurstTyre_Reversed, 0x6C7D30);
+    RH_ScopedInstall(SetUpWheelColModel_Reversed, 0x6C7D20);
 }
 
+// 0x6C8D60
+CMonsterTruck::CMonsterTruck(int32 modelIndex, eVehicleCreatedBy createdBy) : CAutomobile(modelIndex, createdBy, false) {
+    plugin::CallMethod<0x6C8D60, CMonsterTruck*, int32, eVehicleCreatedBy>(this, modelIndex, createdBy);
+    return;
+
+    std::ranges::fill(field_988, 1.0f);
+    SetupSuspensionLines();
+    ucNPCVehicleFlags |= 0x80u;
+    m_nVehicleSubType = VEHICLE_TYPE_MTRUCK;
+}
+
+// 0x6C8AE0
+int32 CMonsterTruck::ProcessEntityCollision(CEntity* entity, CColPoint* colPoint) {
+    return plugin::CallMethodAndReturn<int32, 0x6C8AE0, CMonsterTruck*, CEntity*, CColPoint*>(this, entity, colPoint);
+}
+
+// 0x6C83A0
+void CMonsterTruck::ProcessSuspension() {
+    plugin::CallMethod<0x6C83A0, CMonsterTruck*>(this);
+}
+
+// 0x6C8330
+void CMonsterTruck::ProcessControlCollisionCheck(bool applySpeed) {
+    plugin::CallMethod<0x6C8330, CMonsterTruck*, bool>(this, applySpeed);
+}
+
+// 0x6C8250
+void CMonsterTruck::ProcessControl() {
+    plugin::CallMethod<0x6C8250, CMonsterTruck*>(this);
+}
+
+// 0x6C7FB0
+void CMonsterTruck::SetupSuspensionLines() {
+    plugin::CallMethod<0x6C7FB0, CMonsterTruck*>(this);
+}
+
+// 0x6C7DE0
+void CMonsterTruck::PreRender() {
+    plugin::CallMethod<0x6C7DE0, CMonsterTruck*>(this);
+}
+
+// 0x6C7D80
 void CMonsterTruck::ExtendSuspension() {
-    ((void(__thiscall*)(CMonsterTruck*))0x6C7D80)(this);
+    plugin::CallMethod<0x6C7D80, CMonsterTruck*>(this);
+}
+
+// 0x6C7D40
+void CMonsterTruck::ResetSuspension() {
+    plugin::CallMethod<0x6C7D40, CMonsterTruck*>(this);
+}
+
+// 0x6C7D30
+bool CMonsterTruck::BurstTyre(uint8 tyreComponentId, bool bPhysicalEffect) {
+    return false;
+}
+
+// 0x6C7D20
+bool CMonsterTruck::SetUpWheelColModel(CColModel* colModel) {
+    return false;
 }

--- a/source/game_sa/Entity/Vehicle/MonsterTruck.h
+++ b/source/game_sa/Entity/Vehicle/MonsterTruck.h
@@ -9,48 +9,72 @@
 #include "Automobile.h"
 
 enum eMonsterTruckNodes {
-    MONSTER_NODE_NONE = 0,
-    MONSTER_CHASSIS = 1,
-    MONSTER_WHEEL_RF = 2,
-    MONSTER_WHEEL_RM = 3,
-    MONSTER_WHEEL_RB = 4,
-    MONSTER_WHEEL_LF = 5,
-    MONSTER_WHEEL_LM = 6,
-    MONSTER_WHEEL_LB = 7,
-    MONSTER_DOOR_RF = 8,
-    MONSTER_DOOR_RR = 9,
-    MONSTER_DOOR_LF = 10,
-    MONSTER_DOOR_LR = 11,
-    MONSTER_BUMP_FRONT = 12,
-    MONSTER_BUMP_REAR = 13,
-    MONSTER_WING_RF = 14,
-    MONSTER_WING_LF = 15,
-    MONSTER_BONNET = 16,
-    MONSTER_BOOT = 17,
-    MONSTER_WINDSCREEN = 18,
+    MONSTER_NODE_NONE      = 0,
+    MONSTER_CHASSIS        = 1,
+    MONSTER_WHEEL_RF       = 2,
+    MONSTER_WHEEL_RM       = 3,
+    MONSTER_WHEEL_RB       = 4,
+    MONSTER_WHEEL_LF       = 5,
+    MONSTER_WHEEL_LM       = 6,
+    MONSTER_WHEEL_LB       = 7,
+    MONSTER_DOOR_RF        = 8,
+    MONSTER_DOOR_RR        = 9,
+    MONSTER_DOOR_LF        = 10,
+    MONSTER_DOOR_LR        = 11,
+    MONSTER_BUMP_FRONT     = 12,
+    MONSTER_BUMP_REAR      = 13,
+    MONSTER_WING_RF        = 14,
+    MONSTER_WING_LF        = 15,
+    MONSTER_BONNET         = 16,
+    MONSTER_BOOT           = 17,
+    MONSTER_WINDSCREEN     = 18,
     MONSTER_TRANSMISSION_F = 19,
     MONSTER_TRANSMISSION_R = 20,
-    MONSTER_LOADBAY = 21,
-    MONSTER_MISC_A = 22,
+    MONSTER_LOADBAY        = 21,
+    MONSTER_MISC_A         = 22,
+
     MONSTER_NUM_NODES
 };
 
 class CMonsterTruck : public CAutomobile {
-protected:
-    CMonsterTruck(plugin::dummy_func_t) : CAutomobile(plugin::dummy) {}
 public:
-    float field_988;
-    float field_98C;
-    float field_990;
-    float field_994;
-    float field_998;
+    float field_988[4]; // unused
+    float m_fSuspensionRadius;
 
     static float& DUMPER_COL_ANGLEMULT; // 0.0002f
 
 public:
+    CMonsterTruck(plugin::dummy_func_t) : CAutomobile(plugin::dummy) { /* todo: remove NOTSA */ }
     CMonsterTruck(int32 modelIndex, eVehicleCreatedBy createdBy);
+    ~CMonsterTruck() override = default; // 0x6C7D10, 0x6C7F90
 
+    int32 ProcessEntityCollision(CEntity* entity, CColPoint* colPoint) override;
+    void ProcessSuspension() override;
+    void ProcessControlCollisionCheck(bool applySpeed) override;
+    void ProcessControl() override;
+    void SetupSuspensionLines() override;
+    void PreRender() override;
+    bool BurstTyre(uint8 tyreComponentId, bool bPhysicalEffect) override;
+    bool SetUpWheelColModel(CColModel* colModel) override;
+    void ResetSuspension() override;
     void ExtendSuspension();
+
+private:
+    friend void InjectHooksMain();
+    static void InjectHooks();
+
+    CMonsterTruck* Constructor(int32 modelIndex, eVehicleCreatedBy createdBy) { this->CMonsterTruck::CMonsterTruck(modelIndex, createdBy); return this; };
+    CMonsterTruck* Destructor() { this->CMonsterTruck::~CMonsterTruck(); return this; };
+
+    int32 ProcessEntityCollision_Reversed(CEntity* entity, CColPoint* colPoint) { return CMonsterTruck::ProcessEntityCollision(entity, colPoint); }
+    void ProcessSuspension_Reversed() { CMonsterTruck::ProcessSuspension(); }
+    void ProcessControlCollisionCheck_Reversed(bool applySpeed) { CMonsterTruck::ProcessControlCollisionCheck(applySpeed); }
+    void ProcessControl_Reversed() { CMonsterTruck::ProcessControl(); }
+    void SetupSuspensionLines_Reversed() { CMonsterTruck::SetupSuspensionLines(); }
+    void PreRender_Reversed() { CMonsterTruck::PreRender(); }
+    bool BurstTyre_Reversed(uint8 tyreComponentId, bool bPhysicalEffect) { return CMonsterTruck::BurstTyre(tyreComponentId, bPhysicalEffect); }
+    bool SetUpWheelColModel_Reversed(CColModel* colModel) { return CMonsterTruck::SetUpWheelColModel(colModel); }
+    void ResetSuspension_Reversed() { CMonsterTruck::ResetSuspension(); }
 };
 
 VALIDATE_SIZE(CMonsterTruck, 0x99C);

--- a/source/game_sa/Entity/Vehicle/Plane.cpp
+++ b/source/game_sa/Entity/Vehicle/Plane.cpp
@@ -1,51 +1,247 @@
 #include "StdInc.h"
 
+#include "Plane.h"
+
 int32& CPlane::GenPlane_ModelIndex = *(int32*)0xC1CAD8;
 uint32& CPlane::GenPlane_Status = *(uint32*)0xC1CADC;
 uint32& CPlane::GenPlane_LastTimeGenerated = *(uint32*)0xC1CAE0;
 
 bool& CPlane::GenPlane_Active = *(bool*)0x8D33BC;               // true
-float& CPlane::ANDROM_COL_ANGLE_MULT = *(float*)0x8D33C0;       // 0.00015
-float& CPlane::HARRIER_NOZZLE_ROTATE_LIMIT = *(float*)0x8D33C4; // 5000.0
-float& CPlane::HARRIER_NOZZLE_SWITCH_LIMIT = *(float*)0x8D33C8; // 3000.0
-float& CPlane::PLANE_MIN_PROP_SPEED = *(float*)0x8D33CC;        // 0.05
-float& CPlane::PLANE_STD_PROP_SPEED = *(float*)0x8D33D0;        // 0.18
-float& CPlane::PLANE_MAX_PROP_SPEED = *(float*)0x8D33D4;        // 0.34
-float& CPlane::PLANE_ROC_PROP_SPEED = *(float*)0x8D33D8;        // 0.01
+float& CPlane::ANDROM_COL_ANGLE_MULT = *(float*)0x8D33C0;       // 0.00015f
+float& CPlane::HARRIER_NOZZLE_ROTATE_LIMIT = *(float*)0x8D33C4; // 5000.0f
+float& CPlane::HARRIER_NOZZLE_SWITCH_LIMIT = *(float*)0x8D33C8; // 3000.0f
+float& CPlane::PLANE_MIN_PROP_SPEED = *(float*)0x8D33CC;        // 0.05f
+float& CPlane::PLANE_STD_PROP_SPEED = *(float*)0x8D33D0;        // 0.18f
+float& CPlane::PLANE_MAX_PROP_SPEED = *(float*)0x8D33D4;        // 0.34f
+float& CPlane::PLANE_ROC_PROP_SPEED = *(float*)0x8D33D8;        // 0.01f
 
-extern float& HARRIER_NOZZLE_ROTATERATE = *(float*)0x8D33DC;       // 25.0
-extern float& PLANE_DAMAGE_WAVE_COUNTER_VAR = *(float*)0x8D33E0;   // 0.75
-extern float& PLANE_DAMAGE_THRESHHOLD = *(float*)0x8D33E4;         // 500.0
-extern float& PLANE_DAMAGE_SCALE_MASS = *(float*)0x8D33E8;         // 10000.0
-extern float& PLANE_DAMAGE_DESTROY_THRESHHOLD = *(float*)0x8D33EC; // 5000.0
-extern CVector& vecRCBaronGunPos = *(CVector*)0x8D33F0;            // <0.0f, 0.45, 0.0>
+float& HARRIER_NOZZLE_ROTATERATE = *(float*)0x8D33DC;       // 25.0f
+float& PLANE_DAMAGE_WAVE_COUNTER_VAR = *(float*)0x8D33E0;   // 0.75f
+float& PLANE_DAMAGE_THRESHHOLD = *(float*)0x8D33E4;         // 500.0f
+float& PLANE_DAMAGE_SCALE_MASS = *(float*)0x8D33E8;         // 10000.0f
+float& PLANE_DAMAGE_DESTROY_THRESHHOLD = *(float*)0x8D33EC; // 5000.0f
+CVector& vecRCBaronGunPos = *(CVector*)0x8D33F0;            // <0.0f, 0.45f, 0.0f>
 
 void CPlane::InjectHooks() {
     RH_ScopedClass(CPlane);
     RH_ScopedCategory("Vehicle/Ped");
 
-
+    RH_ScopedInstall(InitPlaneGenerationAndRemoval, 0x6CAD90);
+    RH_ScopedInstall(SetUpWheelColModel_Reversed, 0x6C9140);
+    RH_ScopedInstall(BurstTyre_Reversed, 0x6C9150);
+    // RH_ScopedInstall(PreRender_Reversed, 0x6C94A0);
+    RH_ScopedInstall(Render_Reversed, 0x6CAB70);
+    RH_ScopedInstall(IsAlreadyFlying, 0x6CAB90);
+    RH_ScopedInstall(Fix_Reversed, 0x6CABB0);
+    RH_ScopedInstall(SetupDamageAfterLoad_Reversed, 0x6CAC10);
+    RH_ScopedInstall(SetGearUp, 0x6CAC20);
+    RH_ScopedInstall(SetGearDown, 0x6CAC70);
+    RH_ScopedInstall(OpenDoor_Reversed, 0x6CACB0);
+    // RH_ScopedInstall(ProcessControl_Reversed, 0x6C9260);
+    // RH_ScopedInstall(ProcessControlInputs_Reversed, 0x6CADD0);
+    // RH_ScopedInstall(ProcessFlyingCarStuff_Reversed, 0x6CB7C0);
+    // RH_ScopedInstall(VehicleDamage_Reversed, 0x6CC4B0);
+    RH_ScopedInstall(CountPlanesAndHelis, 0x6CCA50);
+    // RH_ScopedInstall(AreWeInNoPlaneZone, 0x6CCAA0);
+    // RH_ScopedInstall(AreWeInNoBigPlaneZone, 0x6CCBB0);
+    // RH_ScopedInstall(SwitchAmbientPlanes, 0x6CCC50);
+    // RH_ScopedInstall(BlowUpCar_Reversed, 0x6CCCF0);
+    // RH_ScopedInstall(FindPlaneCreationCoors, 0x6CD090);
+    // RH_ScopedInstall(DoPlaneGenerationAndRemoval, 0x6CD2F0);
 }
 
-CPlane::CPlane(int32 modelIndex, eVehicleCreatedBy createdBy) : CAutomobile(plugin::dummy)
-{
+// 0x6C8E20
+CPlane::CPlane(int32 modelIndex, eVehicleCreatedBy createdBy) : CAutomobile({}) /* CAutomobile(modelIndex, createdBy, true) */ {
     plugin::CallMethod<0x6C8E20, CPlane*, int32, eVehicleCreatedBy>(this, modelIndex, createdBy);
+}
+
+// 0x6C9160
+CPlane::~CPlane() {
+    plugin::CallMethod<0x6C9160, CPlane*>(this);
+    return;
+
+    if (m_pGunParticles) {
+        for (auto i = 0; i < CVehicle::GetPlaneNumGuns(); i++) {
+            auto& particle = m_pGunParticles[i];
+            if (particle) {
+                particle->Kill();
+                g_fxMan.DestroyFxSystem(particle);
+            }
+        }
+        delete[] m_pGunParticles;
+        m_pGunParticles = nullptr;
+    }
+
+    for (auto& particle : m_apJettrusParticles) {
+        particle->Kill();
+        particle = nullptr;
+    }
+
+    if (m_pSmokeParticle) {
+        m_pSmokeParticle->Kill();
+        m_pSmokeParticle = nullptr;
+    }
+
+    m_vehicleAudio.Terminate();
+    CAutomobile::~CAutomobile();
+}
+
+// 0x6CAD90
+void CPlane::InitPlaneGenerationAndRemoval() {
+    GenPlane_Status = 0;
+    GenPlane_LastTimeGenerated = 0;
+    GenPlane_Active = true;
 }
 
 // 0x6CCCF0
 void CPlane::BlowUpCar(CEntity* damager, uint8 bHideExplosion) {
-    return BlowUpCar_Reversed(damager, bHideExplosion);
-}
-
-void CPlane::BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion) {
     plugin::CallMethod<0x6CCCF0, CPlane*, CEntity*, uint8>(this, damager, bHideExplosion);
 }
 
 // 0x6CABB0
 void CPlane::Fix() {
-    Fix_Reversed();
+    m_damageManager.ResetDamageStatus();
+    if (m_pHandlingData->m_bNoDoors) {
+        m_damageManager.SetDoorStatus(DOOR_LEFT_FRONT, DAMSTATE_NOTPRESENT);
+        m_damageManager.SetDoorStatus(DOOR_RIGHT_FRONT, DAMSTATE_NOTPRESENT);
+        m_damageManager.SetDoorStatus(DOOR_LEFT_REAR, DAMSTATE_NOTPRESENT);
+        m_damageManager.SetDoorStatus(DOOR_RIGHT_REAR, DAMSTATE_NOTPRESENT);
+    }
+    SetupDamageAfterLoad();
 }
 
-void CPlane::Fix_Reversed() {
-    plugin::CallMethod<0x6CABB0, CPlane*>(this);
+// 0x6CACB0
+void CPlane::OpenDoor(CPed* ped, int32 componentId, eDoors door, float doorOpenRatio, bool playSound) {
+    CAutomobile::OpenDoor(ped, componentId, door, doorOpenRatio, playSound);
+
+    if (m_nModelIndex != MODEL_STUNT)
+        return;
+
+    // Unfinished code R*, which removed in Android
+    if (false) // byte_C1CAFC
+    {
+        CMatrix matrix(&m_aCarNodes[componentId]->modelling, false);
+        const auto y = m_doors[door].m_fAngle - m_doors[door].m_fPrevAngle + matrix.GetPosition().y;
+        matrix.SetTranslate({matrix.GetPosition().x, y, matrix.GetPosition().z});
+        matrix.UpdateRW();
+    }
+}
+
+// 0x6CAC10
+void CPlane::SetupDamageAfterLoad() {
+    vehicleFlags.bIsDamaged = false;
+}
+
+// 0x6CC4B0
+void CPlane::VehicleDamage(float damageIntensity, uint16 collisionComponent, CEntity* damager, CVector* vecCollisionCoors, CVector* vecCollisionDirection, eWeaponType weapon) {
+    plugin::CallMethod<0x6CC4B0, CPlane*, float, uint16, CEntity*, CVector*, CVector*, eWeaponType>(this, damageIntensity, collisionComponent, damager, vecCollisionCoors, vecCollisionDirection, weapon);
+}
+
+// 0x6CAB90
+void CPlane::IsAlreadyFlying() {
+    m_nStartedFlyingTime = CTimer::GetTimeInMS() - 20000;
+}
+
+// 0x6CAC20
+void CPlane::SetGearUp() {
+    m_fLandingGearStatus = 1.0f;
+    m_fAirResistance = m_pHandlingData->m_fDragMult / 1000.0f * 0.5f * m_pFlyingHandlingData->m_fGearUpR;
+    m_damageManager.SetWheelStatus(CARWHEEL_FRONT_LEFT,  WHEEL_STATUS_MISSING);
+    m_damageManager.SetWheelStatus(CARWHEEL_REAR_LEFT,   WHEEL_STATUS_MISSING);
+    m_damageManager.SetWheelStatus(CARWHEEL_FRONT_RIGHT, WHEEL_STATUS_MISSING);
+    m_damageManager.SetWheelStatus(CARWHEEL_REAR_RIGHT,  WHEEL_STATUS_MISSING);
+}
+
+// 0x6CAC70
+void CPlane::SetGearDown() {
+    m_fLandingGearStatus = 0.0f;
+    m_fAirResistance = m_pHandlingData->m_fDragMult / 1000.0f * 0.5f;
+    m_damageManager.SetWheelStatus(CARWHEEL_FRONT_LEFT,  WHEEL_STATUS_OK);
+    m_damageManager.SetWheelStatus(CARWHEEL_REAR_LEFT,   WHEEL_STATUS_OK);
+    m_damageManager.SetWheelStatus(CARWHEEL_FRONT_RIGHT, WHEEL_STATUS_OK);
+    m_damageManager.SetWheelStatus(CARWHEEL_REAR_RIGHT,  WHEEL_STATUS_OK);
+}
+
+// 0x6CCA50
+uint32 CPlane::CountPlanesAndHelis() {
+    auto counter = 0;
+
+    for (auto i = 0; i < CPools::ms_pVehiclePool->GetSize(); i++) {
+        if (auto vehicle = CPools::ms_pVehiclePool->GetAt(i)) {
+            if (vehicle->IsSubHeli() || vehicle->IsSubPlane())
+                counter++;
+        }
+    }
+
+    return counter;
+}
+
+// 0x6CCAA0
+bool CPlane::AreWeInNoPlaneZone() {
+    return plugin::CallAndReturn<bool, 0x6CCAA0>();
+
+    const auto camPos = TheCamera.GetPosition();
+    return sqrt((camPos.z - 50.0f) * (camPos.z - 50.0f) + (camPos.y - -675.0f) * (camPos.y - -675.0f) + (camPos.x - -1073.0f) * (camPos.x - -1073.0)) < 200.0f
+           || camPos.x > -2743.0f && camPos.x < -2626.0f && camPos.y > 1300.0f && camPos.y < 2200.0f
+           || camPos.x > -1668.0f && camPos.x < -1122.0f && camPos.y > 541.0f && camPos.y < 1118.0f;
+}
+
+// 0x6CCBB0
+bool CPlane::AreWeInNoBigPlaneZone() {
+    return plugin::CallAndReturn<bool, 0x6CCBB0>();
+
+    const auto camPos = TheCamera.GetPosition();
+    return sqrt((camPos.y - -1237.0f) * (camPos.y - -1237.0f) + (camPos.x - 1522.0f) * (camPos.x - 1522.0f)) < 800.0f
+           || sqrt((camPos.y - 659.0f) * (camPos.y - 659.0f) + (camPos.x - -1836.0f) * (camPos.x - -1836.0f)) < 800.0f;
+}
+
+// 0x6CCC50
+void CPlane::SwitchAmbientPlanes(bool enable) {
+    plugin::Call<0x6CCC50, bool>(enable);
+}
+
+// 0x6CD090
+void CPlane::FindPlaneCreationCoors(CVector* center, CVector* playerCoords, float* outHeading, float* outHeight, bool arg4) {
+    plugin::Call<0x6CD090, CVector*, CVector*, float*, float*, bool>(center, playerCoords, outHeading, outHeight, arg4);
+}
+
+// 0x6CD2F0
+void CPlane::DoPlaneGenerationAndRemoval() {
+    plugin::Call<0x6CD2F0>();
+}
+
+// 0x6C9140
+bool CPlane::SetUpWheelColModel(CColModel* wheelCol) {
+    return false;
+}
+
+// 0x6C9150
+bool CPlane::BurstTyre(uint8 tyreComponentId, bool bPhysicalEffect) {
+    return false;
+}
+
+// 0x6C94A0
+void CPlane::PreRender() {
+    plugin::CallMethod<0x6C94A0, CPlane*>(this);
+}
+
+// 0x6CAB70
+void CPlane::Render() {
+    m_nTimeTillWeNeedThisCar = CTimer::GetTimeInMS() + 3000;
+    CVehicle::Render();
+}
+
+// 0x6C9260
+void CPlane::ProcessControl() {
+    plugin::CallMethod<0x6C9260, CPlane*>(this);
+}
+
+// 0x6CADD0
+void CPlane::ProcessControlInputs(uint8 playerNum) {
+    plugin::CallMethod<0x6CADD0, CPlane*, uint8>(this, playerNum);
+}
+
+// 0x6CB7C0
+void CPlane::ProcessFlyingCarStuff() {
+    plugin::CallMethod<0x6CB7C0, CPlane*>(this);
 }

--- a/source/game_sa/Entity/Vehicle/Plane.cpp
+++ b/source/game_sa/Entity/Vehicle/Plane.cpp
@@ -24,7 +24,7 @@ CVector& vecRCBaronGunPos = *(CVector*)0x8D33F0;            // <0.0f, 0.45f, 0.0
 
 void CPlane::InjectHooks() {
     RH_ScopedClass(CPlane);
-    RH_ScopedCategory("Vehicle/Ped");
+    RH_ScopedCategory("Vehicle");
 
     RH_ScopedInstall(InitPlaneGenerationAndRemoval, 0x6CAD90);
     RH_ScopedInstall(SetUpWheelColModel_Reversed, 0x6C9140);
@@ -57,9 +57,6 @@ CPlane::CPlane(int32 modelIndex, eVehicleCreatedBy createdBy) : CAutomobile({}) 
 
 // 0x6C9160
 CPlane::~CPlane() {
-    plugin::CallMethod<0x6C9160, CPlane*>(this);
-    return;
-
     if (m_pGunParticles) {
         for (auto i = 0; i < CVehicle::GetPlaneNumGuns(); i++) {
             auto& particle = m_pGunParticles[i];

--- a/source/game_sa/Entity/Vehicle/Plane.h
+++ b/source/game_sa/Entity/Vehicle/Plane.h
@@ -54,7 +54,7 @@ public:
     float        m_planeHeadingPrev;
     float        m_forwardZ;
     uint32       m_nStartedFlyingTime;
-    float        m_propSpeed;
+    float        m_fPropSpeed;
     float        field_9C8;
     float        m_fLandingGearStatus;
     int32        m_planeDamageWave;
@@ -67,7 +67,6 @@ public:
     FxSystem_c*  m_pSmokeParticle;
     uint32       m_nSmokeTimer;
     bool         m_bSmokeEjectorEnabled;
-    char         _pad[3];
 
 public:
     static int32& GenPlane_ModelIndex;

--- a/source/game_sa/Entity/Vehicle/Plane.h
+++ b/source/game_sa/Entity/Vehicle/Plane.h
@@ -38,8 +38,6 @@ enum ePlaneNodes {
 };
 
 class CPlane : public CAutomobile {
-protected:
-    CPlane(plugin::dummy_func_t) : CAutomobile(plugin::dummy) {}
 public:
     float        m_fLeftRightSkid;
     float        m_fSteeringUpDown;
@@ -86,35 +84,55 @@ public:
     static float& PLANE_ROC_PROP_SPEED;         // 0.01
 
 public:
-    static void InjectHooks();
-
+    CPlane(plugin::dummy_func_t) : CAutomobile(plugin::dummy) { /* todo: remove NOTSA */ }
     CPlane(int32 modelIndex, eVehicleCreatedBy createdBy);
+    ~CPlane() override;
 
+    bool SetUpWheelColModel(CColModel* wheelCol) override;
+    bool BurstTyre(uint8 tyreComponentId, bool bPhysicalEffect) override;
+    void ProcessControl() override;
+    void ProcessControlInputs(uint8 playerNum) override;
+    void ProcessFlyingCarStuff() override;
+    void PreRender() override;
+    void Render() override;
     void BlowUpCar(CEntity* damager, uint8 bHideExplosion) override;
     void Fix() override;
+    void OpenDoor(CPed* ped, int32 componentId, eDoors door, float doorOpenRatio, bool playSound) override;
+    void SetupDamageAfterLoad() override;
+    void VehicleDamage(float damageIntensity, uint16 collisionComponent, CEntity* damager, CVector* vecCollisionCoors, CVector* vecCollisionDirection, eWeaponType weapon) override;
+
+    static void InitPlaneGenerationAndRemoval();
 
     void IsAlreadyFlying();
     void SetGearUp();
     void SetGearDown();
 
-    static void InitPlaneGenerationAndRemoval();
     static uint32 CountPlanesAndHelis();
     static bool AreWeInNoPlaneZone();
     static bool AreWeInNoBigPlaneZone();
     static void SwitchAmbientPlanes(bool enable);
-    static void FindPlaneCreationCoors(CVector* arg0, CVector* arg1, float* arg2, float* arg3, bool arg4);
+    static void FindPlaneCreationCoors(CVector* center, CVector* playerCoords, float* outHeading, float* outHeight, bool arg4);
     static void DoPlaneGenerationAndRemoval();
 
 private:
-    void BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion);
-    void Fix_Reversed();
+    friend void InjectHooksMain();
+    static void InjectHooks();
+
+    CPlane* Constructor(int32 modelIndex, eVehicleCreatedBy createdBy) { this->CPlane::CPlane(modelIndex, createdBy); return this; }
+    CPlane* Destroy() { this->CPlane::~CPlane(); return this; }
+
+    bool SetUpWheelColModel_Reversed(CColModel* wheelCol) { return CPlane::SetUpWheelColModel(wheelCol); };
+    bool BurstTyre_Reversed(uint8 tyreComponentId, bool bPhysicalEffect) { return CPlane::BurstTyre(tyreComponentId, bPhysicalEffect); };
+    void ProcessControl_Reversed() { CPlane::ProcessControl(); };
+    void ProcessControlInputs_Reversed(uint8 playerNum) { CPlane::ProcessControlInputs(playerNum); };
+    void ProcessFlyingCarStuff_Reversed() { CPlane::ProcessFlyingCarStuff(); };
+    void PreRender_Reversed() { CPlane::PreRender(); };
+    void Render_Reversed() { CPlane::Render(); };
+    void BlowUpCar_Reversed(CEntity* damager, uint8 bHideExplosion) { CPlane::BlowUpCar(damager, bHideExplosion); };
+    void Fix_Reversed() { CPlane::Fix(); };
+    void OpenDoor_Reversed(CPed* ped, int32 componentId, eDoors door, float doorOpenRatio, bool playSound) { CPlane::OpenDoor(ped, componentId, door, doorOpenRatio, playSound); };
+    void SetupDamageAfterLoad_Reversed() { CPlane::SetupDamageAfterLoad(); };
+    void VehicleDamage_Reversed(float damageIntensity, uint16 collisionComponent, CEntity* damager, CVector* vecCollisionCoors, CVector* vecCollisionDirection, eWeaponType weapon) { CPlane::VehicleDamage(damageIntensity, collisionComponent, damager, vecCollisionCoors, vecCollisionDirection, weapon); };
 };
 
 VALIDATE_SIZE(CPlane, 0xA04);
-
-extern float &HARRIER_NOZZLE_ROTATERATE;        // 25.0
-extern float& PLANE_DAMAGE_WAVE_COUNTER_VAR;    // 0.75
-extern float& PLANE_DAMAGE_THRESHHOLD;          // 500.0
-extern float& PLANE_DAMAGE_SCALE_MASS;          // 10000.0
-extern float& PLANE_DAMAGE_DESTROY_THRESHHOLD;  // 5000.0
-extern CVector& vecRCBaronGunPos;               // <0.0f, 0.45, 0.0>

--- a/source/game_sa/Entity/Vehicle/QuadBike.cpp
+++ b/source/game_sa/Entity/Vehicle/QuadBike.cpp
@@ -34,14 +34,16 @@ CQuadBike::CQuadBike(int32 modelIndex, eVehicleCreatedBy createdBy) : CAutomobil
     m_pHandling = gHandlingDataMgr.GetBikeHandlingPointer(CModelInfo::GetModelInfo(modelIndex)->AsVehicleModelInfoPtr()->m_nHandlingId);
     m_nVehicleSubType = VEHICLE_TYPE_QUAD;
 
-    field_9AC = 0; // unused
-    field_9B0 = 0; // unused
-    field_9B4 = 0; // unused
+    { // unused
+    field_9A8[0] = 0;
+    field_9A8[1] = 0;
+    field_9A8[2] = 0;
+    field_9A8[3] = 1.0f; // see SetupSuspensionLines
+    }
 
-    field_9A8 = 1.0f; // unused, initialised there and in SetupSuspensionLines
     SetupSuspensionLines();
 
-    m_nQuadFlags &= ~1u; // usless
+    m_nQuadFlags &= ~1u; // useless
     m_fSteerAngle = 0.0f;
 }
 
@@ -195,8 +197,7 @@ bool CQuadBike::ProcessAI(uint32& extraHandlingFlags) {
                 }
             }
             const float fValue = std::pow(m_pHandling->m_fDesLean, CTimer::GetTimeStep()); // TODO: Name this variable properly
-            m_sRideAnimData.m_fAnimLean = fValue * m_sRideAnimData.m_fAnimLean
-                                          - m_pHandling->m_fFullAnimLean * m_fSteerAngle / RWDEG2RAD(m_pHandlingData->m_fSteeringLock) * (1.0f - fValue);
+            m_sRideAnimData.m_fAnimLean = fValue * m_sRideAnimData.m_fAnimLean - m_pHandling->m_fFullAnimLean * m_fSteerAngle / RWDEG2RAD(m_pHandlingData->m_fSteeringLock) * (1.0f - fValue);
                 
             DoDriveByShootings();
 
@@ -211,46 +212,43 @@ bool CQuadBike::ProcessAI(uint32& extraHandlingFlags) {
 
 // 0x6CDCC0
 void CQuadBike::ProcessControl() {
-    if (m_nStatus == STATUS_PLAYER && bDoQuadDamping) {
-        const auto turnSpeed_Mult_Matrix = Multiply3x3(m_vecTurnSpeed, *m_matrix);
-        float v2 = vecQuadResistance.y, v5 = vecQuadResistance.x;
-        if (AreFrontWheelsNotTouchingGround()) {
-            if (!AreRearWheelsNotTouchingGround() && m_matrix->GetForward().z > 0.0f) {
-                v5 = vecQuadResistance.x - std::min(0.07f, fabs(m_pHandling->m_fWheelieAng - m_matrix->GetForward().z) * 0.25f);
+    if (m_nStatus != STATUS_PLAYER || !bDoQuadDamping) {
+        CAutomobile::ProcessControl();
+        return;
+    }
+
+    const auto turnSpeed_Mult_Matrix = Multiply3x3(m_vecTurnSpeed, *m_matrix);
+    float v2 = vecQuadResistance.y, v5 = vecQuadResistance.x;
+    if (AreFrontWheelsNotTouchingGround()) {
+        if (!AreRearWheelsNotTouchingGround() && m_matrix->GetForward().z > 0.0f) {
+            v5 = vecQuadResistance.x - std::min(0.07f, fabs(m_pHandling->m_fWheelieAng - m_matrix->GetForward().z) * 0.25f);
+        }
+    } else {
+        if (m_aWheelTimer[eCarWheel::CARWHEEL_REAR_LEFT] == 1.0f && m_aWheelTimer[eCarWheel::CARWHEEL_REAR_RIGHT] == 1.0f) {
+            if (m_matrix->GetForward().z < 0.0f) {
+                v5 = vecQuadResistance.x * (0.9f + std::min(0.1f, fabs(m_pHandling->m_fStoppieAng - m_matrix->GetForward().z) * 0.3f));
             }
         } else {
-            if (m_aWheelTimer[eCarWheel::CARWHEEL_REAR_LEFT] == 1.0f && m_aWheelTimer[eCarWheel::CARWHEEL_REAR_RIGHT] == 1.0f) {
-                if (m_matrix->GetForward().z < 0.0f) {
-                    v5 = vecQuadResistance.x * (0.9f + std::min(0.1f, fabs(m_pHandling->m_fStoppieAng - m_matrix->GetForward().z) * 0.3f));
-                }
-            } else {
-                v2 = 0.5f;
-            }
+            v2 = 0.5f;
         }
-        const CVector worldSpaceSpeed = Multiply3x3(m_vecTurnSpeed, *m_matrix);
-        CVector unk{
-            // In the original code `x` is calculated once then immediately overwritten by the below line
-            std::pow(vecQuadResistance.x, CTimer::GetTimeStep()),
-            vecQuadResistance.y / (worldSpaceSpeed.y * worldSpaceSpeed.y + 1.0f),
-            1.0f
-        };
-        const auto worldCentreOfMass = Multiply3x3(m_vecCentreOfMass, *m_matrix);
-
-        const float v9 = std::pow(unk.y, CTimer::GetTimeStep()) * worldSpaceSpeed.y - worldSpaceSpeed.y;
-        ApplyTurnForce(
-            m_matrix->GetUp() * -1.0f * v9 * m_fTurnMass,
-            m_matrix->GetRight() + worldCentreOfMass
-        );
-
-        const float v19 = worldSpaceSpeed.x * unk.x - worldSpaceSpeed.x;
-        ApplyTurnForce(
-            m_matrix->GetUp() * v19 * m_fTurnMass,
-            m_matrix->GetForward() + worldCentreOfMass
-        );
     }
+
+    const CVector worldSpaceSpeed = Multiply3x3(m_vecTurnSpeed, *m_matrix);
+    CVector unk{ // In the original code `x` is calculated once then immediately overwritten by the below line
+        std::pow(vecQuadResistance.x, CTimer::GetTimeStep()),
+        vecQuadResistance.y / (worldSpaceSpeed.y * worldSpaceSpeed.y + 1.0f),
+        1.0f
+    };
+    const auto worldCentreOfMass = Multiply3x3(m_vecCentreOfMass, *m_matrix);
+
+    const float v9 = std::pow(unk.y, CTimer::GetTimeStep()) * worldSpaceSpeed.y - worldSpaceSpeed.y;
+    ApplyTurnForce(m_matrix->GetUp() * -1.0f * v9 * m_fTurnMass, m_matrix->GetRight() + worldCentreOfMass);
+
+    const float v19 = worldSpaceSpeed.x * unk.x - worldSpaceSpeed.x;
+    ApplyTurnForce(m_matrix->GetUp() * v19 * m_fTurnMass, m_matrix->GetForward() + worldCentreOfMass);
+
     CAutomobile::ProcessControl();
 }
-
 
 // 0x6CE020
 void CQuadBike::ProcessControlInputs(uint8 playerNum) {
@@ -284,8 +282,8 @@ void CQuadBike::ProcessControlInputs(uint8 playerNum) {
 
 // 0x6CE280
 void CQuadBike::ProcessDrivingAnims(CPed* driver, uint8 bBlend) {
-    if (!m_bOffscreen) {
-        CBike::ProcessRiderAnims(driver, this, &m_sRideAnimData, m_pHandling);
+    if (!m_bOffscreen) { // see CBike::ProcessDrivingAnims
+        CBike::ProcessRiderAnims(driver, this, &m_sRideAnimData, m_pHandling, 0);
     }
 }
 
@@ -310,6 +308,6 @@ void CQuadBike::SetupDamageAfterLoad() {
 
 // 0x6CDCA0
 void CQuadBike::SetupSuspensionLines() {
-    field_9A8 = 1.0f;
+    field_9A8[0] = 1.0f;
     CAutomobile::SetupSuspensionLines();
 }

--- a/source/game_sa/Entity/Vehicle/QuadBike.cpp
+++ b/source/game_sa/Entity/Vehicle/QuadBike.cpp
@@ -8,7 +8,7 @@ CVector& vecQuadResistance = *(CVector*)0x8D3458; // { 0.995f, 0.995f, 1.0f } //
 
 void CQuadBike::InjectHooks() {
     RH_ScopedClass(CQuadBike);
-    RH_ScopedCategory("Vehicle/Ped");
+    RH_ScopedCategory("Vehicle");
 
 // todo: RH_ScopedInstall(Constructor, 0x6CE370);
     RH_ScopedInstall(Fix_Reversed, 0x6CE2B0);
@@ -76,18 +76,18 @@ void CQuadBike::PreRender() {
     auto modelInfo = CModelInfo::GetModelInfo(m_nModelIndex)->AsVehicleModelInfoPtr();
     {
         CVector wheelPos;
-        modelInfo->GetWheelPosn(eCarWheel::CARWHEEL_REAR_LEFT, wheelPos, false);
+        modelInfo->GetWheelPosn(CARWHEEL_REAR_LEFT, wheelPos, false);
         SetTransmissionRotation(
-            m_aCarNodes[eQuadBikeNodes::QUAD_REAR_AXLE],
-            m_wheelPosition[eCarWheel::CARWHEEL_REAR_LEFT],
-            m_wheelPosition[eCarWheel::CARWHEEL_REAR_RIGHT],
+            m_aCarNodes[QUAD_REAR_AXLE],
+            m_wheelPosition[CARWHEEL_REAR_LEFT],
+            m_wheelPosition[CARWHEEL_REAR_RIGHT],
             wheelPos,
             false
         );
     }
     
     CVector wheelFrontLeftPos;
-    modelInfo->GetWheelPosn(eCarWheel::CARWHEEL_FRONT_LEFT, wheelFrontLeftPos, false);
+    modelInfo->GetWheelPosn(CARWHEEL_FRONT_LEFT, wheelFrontLeftPos, false);
     
     // Original code saves position of each matrix (because calls to SetRotation set the pos. to 0), then restores it
     // We just use SetRotateYOnly which doesn't modify the position
@@ -95,7 +95,7 @@ void CQuadBike::PreRender() {
     if (auto suspensionLF = m_aCarNodes[eQuadBikeNodes::QUAD_SUSPENSION_LF]) {
         CMatrix mat;
         mat.Attach(&suspensionLF->modelling, false);
-        mat.SetRotateYOnly(atan2(m_wheelPosition[eCarWheel::CARWHEEL_FRONT_LEFT] - wheelFrontLeftPos.z, fabs(wheelFrontLeftPos.x)));
+        mat.SetRotateYOnly(atan2(m_wheelPosition[CARWHEEL_FRONT_LEFT] - wheelFrontLeftPos.z, fabs(wheelFrontLeftPos.x)));
         mat.UpdateRW();
     }
     
@@ -224,7 +224,7 @@ void CQuadBike::ProcessControl() {
             v5 = vecQuadResistance.x - std::min(0.07f, fabs(m_pHandling->m_fWheelieAng - m_matrix->GetForward().z) * 0.25f);
         }
     } else {
-        if (m_aWheelTimer[eCarWheel::CARWHEEL_REAR_LEFT] == 1.0f && m_aWheelTimer[eCarWheel::CARWHEEL_REAR_RIGHT] == 1.0f) {
+        if (m_aWheelTimer[CARWHEEL_REAR_LEFT] == 1.0f && m_aWheelTimer[CARWHEEL_REAR_RIGHT] == 1.0f) {
             if (m_matrix->GetForward().z < 0.0f) {
                 v5 = vecQuadResistance.x * (0.9f + std::min(0.1f, fabs(m_pHandling->m_fStoppieAng - m_matrix->GetForward().z) * 0.3f));
             }

--- a/source/game_sa/Entity/Vehicle/QuadBike.h
+++ b/source/game_sa/Entity/Vehicle/QuadBike.h
@@ -30,6 +30,7 @@ enum eQuadBikeNodes {
     QUAD_HANDLEBARS = 17,
     QUAD_MISC_A = 18,
     QUAD_MISC_B = 19,
+
     QUAD_NUM_NODES
 };
 
@@ -37,12 +38,8 @@ class CQuadBike : public CAutomobile {
 public:
     tBikeHandlingData* m_pHandling;
     CRideAnimData      m_sRideAnimData;
-    float              field_9A8;
-    int32              field_9AC;
-    int32              field_9B0;
-    int32              field_9B4;
+    float              field_9A8[4]; // unused
     uint8              m_nQuadFlags;
-    char               _pad1[3];
 
 public:
     CQuadBike(int32 modelIndex, eVehicleCreatedBy createdBy);

--- a/source/game_sa/Entity/Vehicle/Trailer.cpp
+++ b/source/game_sa/Entity/Vehicle/Trailer.cpp
@@ -8,8 +8,27 @@ static float& RELINK_TRAILER_DIFF_LIMIT_Z = *(float*)0x8D3474;  // 1.0f
 static float& m_fTrailerSuspensionForce = *(float*)0x8D3464;    // 1.5f
 static float& m_fTrailerDampingForce = *(float*)0x8D3468;       // 0.1f
 
+void CTrailer::InjectHooks() {
+    RH_ScopedClass(CTrailer);
+    RH_ScopedCategory("Vehicle/Ped");
+
+    // RH_ScopedInstall(Constructor, 0x6D03A0);
+    // RH_ScopedInstall(SetupSuspensionLines, 0x6CF1A0);
+    // RH_ScopedInstall(SetTowLink, 0x6CFDF0);
+    // RH_ScopedInstall(ScanForTowLink, 0x6CF030);
+    RH_ScopedInstall(ResetSuspension, 0x6CEE50);
+    // RH_ScopedInstall(ProcessSuspension, 0x6CF6A0);
+    // RH_ScopedInstall(ProcessEntityCollision, 0x6CFFD0);
+    // RH_ScopedInstall(ProcessControl, 0x6CED20);
+    // RH_ScopedInstall(ProcessAI, 0x6CF590);
+    // RH_ScopedInstall(PreRender, 0x6CFAC0);
+    // RH_ScopedInstall(GetTowHitchPos, 0x6CEEA0);
+    // RH_ScopedInstall(GetTowBarPos, 0x6CFD60);
+    // RH_ScopedInstall(BreakTowLink, 0x6CEFB0);
+}
+
 // 0x6D03A0
-CTrailer::CTrailer(int32 modelIndex, eVehicleCreatedBy createdBy) : CAutomobile({}) {
+CTrailer::CTrailer(int32 modelIndex, eVehicleCreatedBy createdBy) : CAutomobile(modelIndex, createdBy, false) {
     plugin::CallMethod<0x6D03A0, CTrailer*, int32, eVehicleCreatedBy>(this, modelIndex, createdBy);
     /*
     m_fTrailerColPointValue1 = 1.0f;
@@ -93,68 +112,4 @@ bool CTrailer::GetTowBarPos(CVector& outPos, bool bCheckModelInfo, CVehicle* veh
 // 0x6CEFB0
 bool CTrailer::BreakTowLink() {
     return plugin::CallMethodAndReturn<bool, 0x6CEFB0, CTrailer*>(this);
-}
-
-void CTrailer::InjectHooks() {
-    RH_ScopedClass(CTrailer);
-    RH_ScopedCategory("Vehicle/Ped");
-
-    // RH_ScopedInstall(Constructor, 0x6D03A0);
-    // RH_ScopedInstall(SetupSuspensionLines, 0x6CF1A0);
-    // RH_ScopedInstall(SetTowLink, 0x6CFDF0);
-    // RH_ScopedInstall(ScanForTowLink, 0x6CF030);
-    RH_ScopedInstall(ResetSuspension, 0x6CEE50);
-    // RH_ScopedInstall(ProcessSuspension, 0x6CF6A0);
-    // RH_ScopedInstall(ProcessEntityCollision, 0x6CFFD0);
-    // RH_ScopedInstall(ProcessControl, 0x6CED20);
-    // RH_ScopedInstall(ProcessAI, 0x6CF590);
-    // RH_ScopedInstall(PreRender, 0x6CFAC0);
-    // RH_ScopedInstall(GetTowHitchPos, 0x6CEEA0);
-    // RH_ScopedInstall(GetTowBarPos, 0x6CFD60);
-    // RH_ScopedInstall(BreakTowLink, 0x6CEFB0);
-}
-
-CTrailer* CTrailer::Constructor(int32 modelIndex, eVehicleCreatedBy createdBy) {
-    this->CTrailer::CTrailer(modelIndex, createdBy);
-    return this;
-}
-
-bool CTrailer::SetTowLink_Reversed(CVehicle* targetVehicle, bool arg1) {
-    return CTrailer::SetTowLink(targetVehicle, arg1);
-}
-
-void CTrailer::SetupSuspensionLines_Reversed() {
-    CTrailer::SetupSuspensionLines();
-}
-
-void CTrailer::ResetSuspension_Reversed() {
-    CTrailer::ResetSuspension();
-}
-
-void CTrailer::ProcessSuspension_Reversed() {
-    CTrailer::ProcessSuspension();
-}
-
-void CTrailer::ProcessControl_Reversed() {
-    CTrailer::ProcessControl();
-}
-
-bool CTrailer::ProcessAI_Reversed(uint32& extraHandlingFlags) {
-    return CTrailer::ProcessAI(extraHandlingFlags);
-}
-
-void CTrailer::PreRender_Reversed() {
-    CTrailer::PreRender();
-}
-
-bool CTrailer::GetTowHitchPos_Reversed(CVector& outPos, bool bCheckModelInfo, CVehicle* vehicle) {
-    return CTrailer::GetTowHitchPos(outPos, bCheckModelInfo, vehicle);
-}
-
-bool CTrailer::GetTowBarPos_Reversed(CVector& outPos, bool bCheckModelInfo, CVehicle* vehicle) {
-    return CTrailer::GetTowBarPos(outPos, bCheckModelInfo, vehicle);
-}
-
-bool CTrailer::BreakTowLink_Reversed() {
-    return CTrailer::BreakTowLink();
 }

--- a/source/game_sa/Entity/Vehicle/Trailer.cpp
+++ b/source/game_sa/Entity/Vehicle/Trailer.cpp
@@ -10,7 +10,7 @@ static float& m_fTrailerDampingForce = *(float*)0x8D3468;       // 0.1f
 
 void CTrailer::InjectHooks() {
     RH_ScopedClass(CTrailer);
-    RH_ScopedCategory("Vehicle/Ped");
+    RH_ScopedCategory("Vehicle");
 
     // RH_ScopedInstall(Constructor, 0x6D03A0);
     // RH_ScopedInstall(SetupSuspensionLines, 0x6CF1A0);

--- a/source/game_sa/Entity/Vehicle/Trailer.h
+++ b/source/game_sa/Entity/Vehicle/Trailer.h
@@ -56,7 +56,7 @@ public:
     void ResetSuspension() override;
     void ProcessSuspension() override;
 
-    int32 ProcessEntityCollision(CEntity* entity, CColPoint* colPoint);
+    int32 ProcessEntityCollision(CEntity* entity, CColPoint* colPoint) override;
     void  ProcessControl() override;
     bool  ProcessAI(uint32& extraHandlingFlags) override;
 
@@ -70,18 +70,18 @@ private:
     friend void InjectHooksMain();
     static void InjectHooks();
 
-    CTrailer* Constructor(int32 modelIndex, eVehicleCreatedBy createdBy);
+    CTrailer* Constructor(int32 modelIndex, eVehicleCreatedBy createdBy) { this->CTrailer::CTrailer(modelIndex, createdBy); return this; }
+    bool SetTowLink_Reversed(CVehicle* targetVehicle, bool arg1) { return CTrailer::SetTowLink(targetVehicle, arg1); }
+    void SetupSuspensionLines_Reversed() { CTrailer::SetupSuspensionLines(); }
+    void ResetSuspension_Reversed() { CTrailer::ResetSuspension(); }
+    void ProcessSuspension_Reversed() { CTrailer::ProcessSuspension(); }
+    void ProcessControl_Reversed() { CTrailer::ProcessControl(); }
+    bool ProcessAI_Reversed(uint32& extraHandlingFlags) { return CTrailer::ProcessAI(extraHandlingFlags); }
+    void PreRender_Reversed() { CTrailer::PreRender(); }
+    bool GetTowHitchPos_Reversed(CVector& outPos, bool bCheckModelInfo, CVehicle* vehicle) { return CTrailer::GetTowHitchPos(outPos, bCheckModelInfo, vehicle); }
+    bool GetTowBarPos_Reversed(CVector& outPos, bool bCheckModelInfo, CVehicle* vehicle) { return CTrailer::GetTowBarPos(outPos, bCheckModelInfo, vehicle); }
+    bool BreakTowLink_Reversed() { return CTrailer::BreakTowLink(); }
 
-    bool SetTowLink_Reversed(CVehicle* targetVehicle, bool arg1);
-    void SetupSuspensionLines_Reversed();
-    void ResetSuspension_Reversed();
-    void ProcessSuspension_Reversed();
-    void ProcessControl_Reversed();
-    bool ProcessAI_Reversed(uint32& extraHandlingFlags);
-    void PreRender_Reversed();
-    bool GetTowHitchPos_Reversed(CVector& outPos, bool bCheckModelInfo, CVehicle* vehicle);
-    bool GetTowBarPos_Reversed(CVector& outPos, bool bCheckModelInfo, CVehicle* vehicle);
-    bool BreakTowLink_Reversed();
 };
 
 VALIDATE_SIZE(CTrailer, 0x9F4);

--- a/source/game_sa/Entity/Vehicle/Train.cpp
+++ b/source/game_sa/Entity/Vehicle/Train.cpp
@@ -4,7 +4,6 @@
     https://github.com/DK22Pac/plugin-sdk
     Do not delete this comment block. Respect others' work!
 */
-
 #include "StdInc.h"
 
 #include "Train.h"
@@ -18,11 +17,19 @@ uint8& CTrain::GenTrain_Direction = *(uint8*)0xC38004;
 uint32& CTrain::GenTrain_GenerationNode = *(uint32*)0xC38008;
 uint32& CTrain::GenTrain_Status = *(uint32*)0xC3800C;
 bool& CTrain::bDisableRandomTrains = *(bool*)0xC38010;
-CVector* CTrain::aStationCoors = (CVector*)0x8D48F8;
-uint32* NumTrackNodes = (uint32*)0xC38014;
-float* arrTotalTrackLength = (float*)0xC37FEC;
-CTrainNode** trackNodes = (CTrainNode * *)0xC38024;
-float* StationDist = (float*)0xC38034;
+CVector (&CTrain::aStationCoors)[6] = *(CVector(*)[6])0x8D48F8; /*{ // 0x8D48F8
+    CVector{ 1741.0f, -1954.0f, 15.0f },
+    CVector{ 1297.0f, -1898.0f, 3.0f  },
+    CVector{ -1945.0f, 128.0f,  29.0f },
+    CVector{ 1434.0f,  2632.0f, 13.0f },
+    CVector{ 2783.0f,  1758.0f, 12.0f },
+    CVector{ 2865.0f,  1281.0f, 12.0  }
+};*/
+
+uint32 (&NumTrackNodes)[4] = *(uint32(*)[4])0xC38014;
+float (&arrTotalTrackLength)[4] = *(float (*)[4])0xC37FEC;
+CTrainNode* (&trackNodes)[4] = *(CTrainNode*(*)[4])0xC38024;
+float (&StationDist)[6] = *(float (*)[6])0xC38034;
 
 void CTrain::InjectHooks()
 {
@@ -33,8 +40,75 @@ void CTrain::InjectHooks()
 }
 
 // 0x6F6030
-CTrain::CTrain(int32 modelIndex, eVehicleCreatedBy createdBy) : CVehicle(plugin::dummy) {
+CTrain::CTrain(int32 modelIndex, eVehicleCreatedBy createdBy) : CVehicle(createdBy) {
     plugin::CallMethod<0x6F6030, CTrain*, int32, eVehicleCreatedBy>(this, modelIndex, createdBy);
+    return;
+
+    const auto mi = CModelInfo::GetModelInfo(modelIndex)->AsVehicleModelInfoPtr();
+
+    memset(&m_aDoors, 0, sizeof(m_aDoors));
+    m_nVehicleSubType = VEHICLE_TYPE_TRAIN;
+    m_nVehicleType = VEHICLE_TYPE_TRAIN;
+    // m_pHandlingData = &handling.mod_HandlingManager.vehicleHandling[mi->m_nHandlingId];
+    // m_nHandlingFlags = m_pHandlingData->m_handlingFlags;
+    CVehicle::SetModelIndex(modelIndex);
+
+    // todo: add as NOTSA add SetupModelNodes
+    std::ranges::fill(m_aTrainNodes, nullptr);
+    CClumpModelInfo::FillFrameArray(m_pRwClump, m_aTrainNodes);
+    //
+
+    m_aDoors[2].m_nDirn = 20;
+    m_aDoors[2].m_nAxis = 2;
+    if (m_nModelIndex == MODEL_STREAKC) {
+        m_aDoors[2].m_fOpenAngle = 1.25f;
+        m_aDoors[2].m_fClosedAngle = 0.25f;
+        m_aDoors[3].m_fOpenAngle = 1.25f;
+        m_aDoors[3].m_fClosedAngle = 0.25f;
+    } else {
+        m_aDoors[2].m_fOpenAngle = -1.2566371;
+        m_aDoors[2].m_fClosedAngle = 0.0f;
+        m_aDoors[3].m_fOpenAngle = 1.2566371;
+        m_aDoors[3].m_fClosedAngle = 0.0f;
+    }
+    m_aDoors[3].m_nAxis = 2;
+    m_aDoors[3].m_nDirn = 20;
+
+    // m_nTrainFlags = m_nTrainFlags & (CLOCKWISE_DIRECTION | IS_LAST_CARRIAGE | IS_FRONT_CARRIAGE) | TF_80 | TF_1;
+    // m_nTrainFlags = m_nTrainFlags & 0xF8 | 2;
+
+    m_nPassengersGenerationState = 0;
+    // m_nPassengerFlags = m_nPassengerFlags & 0xF0 | rand() & 3;
+    // m_nPassengerFlags = m_nPassengerFlags & 0xF | (16 * ((rand() & 3) + 1));
+    m_pTemporaryPassenger = nullptr;
+    m_nMaxPassengers = 5;
+    m_nPhysicalFlags = m_nPhysicalFlags | 0x20000; // b18;
+    m_nFlags = m_nFlags | 1;                       // uses collision
+    m_nTimeWhenCreated = CTimer::GetTimeInMS();
+    field_5C8 = 0;
+    m_nTrackId = 0;
+    m_fCurrentRailDistance = 0.0f;
+    m_fTrainSpeed = 0.0f;
+    m_nTimeWhenStoppedAtStation = 0;
+    mi->ChooseVehicleColour(m_nPrimaryColor, m_nSecondaryColor, m_nTertiaryColor, m_nQuaternaryColor, 1);
+    m_fMass = m_pHandlingData->m_fMass;
+    m_fTurnMass = m_pHandlingData->m_fTurnMass;
+    m_vecCentreOfMass = (CVector)m_pHandlingData->m_vecCentreOfMass;
+    m_fElasticity = 0.05f;
+    m_fBuoyancyConstant = m_pHandlingData->m_fBuoyancyConstant;
+    if (m_pHandlingData->m_fDragMult <= 0.01f)
+        m_fAirResistance = m_pHandlingData->m_fDragMult;
+    else
+        m_fAirResistance = m_pHandlingData->m_fDragMult / 1000.0f * 0.5f; // pattern: see CPlane::SetGearDown
+
+    m_nPhysicalFlags = m_nPhysicalFlags & 0xFFFFFFF3 | 4; // bDisableCollisionForce
+    m_nFlags = m_nFlags | 0x80000000;                     // m_bTunnelTransition
+    m_pPrevCarriage = nullptr;
+    m_pNextCarriage = nullptr;
+    // m_nType = (m_nType & 7) | 0x30;
+    m_autoPilot.m_speed = 0.0f;
+    m_autoPilot.m_nCruiseSpeed = 0;
+    m_vehicleAudio.Initialise(this);
 }
 
 // 0x6F55D0
@@ -84,22 +158,22 @@ void TrainHitStuff(CPtrList& ptrList, CEntity* entity) {
 
 // 0x6F5D80
 void CTrain::OpenTrainDoor(float state) {
-    ((void(__thiscall*)(CTrain*, float))0x6F5D80)(this, state);
+    // NOP
 }
 
 // 0x6F5D90
 void CTrain::AddPassenger(CPed* ped) {
-    ((void(__thiscall*)(CTrain*, CPed*))0x6F5D90)(this, ped);
+    // NOP
 }
 
 // 0x6F5DA0
 void CTrain::RemovePassenger(CPed* ped) {
-    ((void(__thiscall*)(CTrain*, CPed*))0x6F5DA0)(this, ped);
+    // NOP
 }
 
 // 0x6F5DB0
 void CTrain::DisableRandomTrains(bool disable) {
-    ((void(__cdecl*)(bool))0x6F5DB0)(disable);
+    bDisableRandomTrains = disable;
 }
 
 // 0x6F5DC0
@@ -230,11 +304,6 @@ void CTrain::AddNearbyPedAsRandomPassenger() {
 // 0x6F86A0
 void CTrain::ProcessControl()
 {
-    CTrain::ProcessControl_Reversed();
-}
-
-void CTrain::ProcessControl_Reversed()
-{
     vehicleFlags.bWarnedPeds = 0;
     m_vehicleAudio.Service();
     if (gbModelViewer)
@@ -336,7 +405,7 @@ void CTrain::ProcessControl_Reversed()
             if (m_nStatus)
             {
                 bool bIsStreakModel = trainFlags.bIsStreakModel;
-                float fStopAtStationSpeed = static_cast<float>(m_autoPilot.m_nCruiseSpeed);
+                auto fStopAtStationSpeed = static_cast<float>(m_autoPilot.m_nCruiseSpeed);
 
                 uint32 timeInMilliSeconds = CTimer::GetTimeInMS();
                 uint32 timeAtStation = CTimer::GetTimeInMS() - m_nTimeWhenStoppedAtStation;

--- a/source/game_sa/Entity/Vehicle/Train.cpp
+++ b/source/game_sa/Entity/Vehicle/Train.cpp
@@ -34,7 +34,7 @@ float (&StationDist)[6] = *(float (*)[6])0xC38034;
 void CTrain::InjectHooks()
 {
     RH_ScopedClass(CTrain);
-    RH_ScopedCategory("Vehicle/Ped");
+    RH_ScopedCategory("Vehicle");
 
     RH_ScopedInstall(ProcessControl_Reversed, 0x6F86A0);
 }

--- a/source/game_sa/Entity/Vehicle/Train.h
+++ b/source/game_sa/Entity/Vehicle/Train.h
@@ -11,23 +11,24 @@
 #include "TrainNode.h"
 
 enum eTrainNodes {
-    TRAIN_NODE_NONE = 0,
-    TRAIN_DOOR_LF = 1,
-    TRAIN_DOOR_RF = 2,
-    TRAIN_WHEEL_RF1 = 3,
-    TRAIN_WHEEL_RF2 = 4,
-    TRAIN_WHEEL_RF3 = 5,
-    TRAIN_WHEEL_RB1 = 6,
-    TRAIN_WHEEL_RB2 = 7,
-    TRAIN_WHEEL_RB3 = 8,
-    TRAIN_WHEEL_LF1 = 9,
-    TRAIN_WHEEL_LF2 = 10,
-    TRAIN_WHEEL_LF3 = 11,
-    TRAIN_WHEEL_LB1 = 12,
-    TRAIN_WHEEL_LB2 = 13,
-    TRAIN_WHEEL_LB3 = 14,
+    TRAIN_NODE_NONE   = 0,
+    TRAIN_DOOR_LF     = 1,
+    TRAIN_DOOR_RF     = 2,
+    TRAIN_WHEEL_RF1   = 3,
+    TRAIN_WHEEL_RF2   = 4,
+    TRAIN_WHEEL_RF3   = 5,
+    TRAIN_WHEEL_RB1   = 6,
+    TRAIN_WHEEL_RB2   = 7,
+    TRAIN_WHEEL_RB3   = 8,
+    TRAIN_WHEEL_LF1   = 9,
+    TRAIN_WHEEL_LF2   = 10,
+    TRAIN_WHEEL_LF3   = 11,
+    TRAIN_WHEEL_LB1   = 12,
+    TRAIN_WHEEL_LB2   = 13,
+    TRAIN_WHEEL_LB3   = 14,
     TRAIN_BOGIE_FRONT = 15,
-    TRAIN_BOGIE_REAR = 16,
+    TRAIN_BOGIE_REAR  = 16,
+
     TRAIN_NUM_NODES
 };
 
@@ -40,11 +41,8 @@ enum eTrainPassengersGenerationState {
 };
 
 class CTrain : public CVehicle {
-protected:
-    CTrain(plugin::dummy_func_t) : CVehicle(plugin::dummy) {}
 public:
     int16    m_nNodeIndex;
-    char     _pad1[2];
     float    m_fTrainSpeed; // 1.0 - train derails
     float    m_fCurrentRailDistance;
     float    m_fLength;
@@ -67,10 +65,8 @@ public:
         } trainFlags;
         uint16 m_nTrainFlags;
     };
-    char     _pad5BA[2];
     int32    m_nTimeWhenStoppedAtStation;
     char     m_nTrackId;
-    char     _pad5C1[3];
     int32    m_nTimeWhenCreated;
     int16    field_5C8;                    // initialized with 0, not referenced
     uint8    m_nPassengersGenerationState; // see eTrainPassengersGenerationState
@@ -88,29 +84,18 @@ public:
     static uint32& GenTrain_GenerationNode;
     static uint32& GenTrain_Status;
     static bool& bDisableRandomTrains;
+    static CVector (&aStationCoors)[6];
 
-    static CVector *aStationCoors; // { 1741.0, -1954.0, 15.0
-                                   //   1297.0, -1898.0, 3.0
-                                   //   -1945.0, 128.0, 29.0
-                                   //   1434.0, 2632.0, 13.0
-                                   //   2783.0, 1758.0, 12.0
-                                   //   2865.0, 1281.0, 12.0 }
-
-    static void InjectHooks();
-
-    // virtual functions
-    void ProcessControl() override;
-
-    // reversed virtual functions
-    void ProcessControl_Reversed();
-
+public:
     CTrain(int32 modelIndex, eVehicleCreatedBy createdBy);
+
+    void ProcessControl() override;
 
     bool FindMaximumSpeedToStopAtStations(float* speed);
     uint32 FindNumCarriagesPulled();
-    void OpenTrainDoor(float state); // dummy function
-    void AddPassenger(CPed* ped); // dummy function
-    void RemovePassenger(CPed* ped); // dummy function
+    void OpenTrainDoor(float state);
+    void AddPassenger(CPed* ped);
+    void RemovePassenger(CPed* ped);
     bool FindSideStationIsOn(); 
     bool IsInTunnel();
     void RemoveRandomPassenger();
@@ -141,14 +126,15 @@ public:
     static void InitTrains();
     static void CreateMissionTrain(CVector posn, bool clockwiseDirection, uint32 trainType, CTrain**outFirstCarriage, CTrain**outLastCarriage, int32 nodeIndex, int32 trackId, bool isMissionTrain);
     static void DoTrainGenerationAndRemoval();
+
+private:
+    friend void InjectHooksMain();
+    static void InjectHooks();
+
+    void ProcessControl_Reversed() { CTrain::ProcessControl(); }
 };
 
 VALIDATE_SIZE(CTrain, 0x6AC);
-
-extern uint32 *NumTrackNodes; // uint32 NumTrackNodes[4]
-extern float* arrTotalTrackLength; // float arrTotalTrackLength[4]
-extern CTrainNode **trackNodes; // CTrainNode *trackNodes[4]
-extern float *StationDist; // float StationDist[6]
 
 void ProcessTrainAnnouncements(); // dummy function
 void PlayAnnouncement(uint8 arg0, uint8 arg1);

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -13,49 +13,50 @@
 #include "Radar.h"
 #include "VehicleSaveStructure.h"
 
-float& CVehicle::WHEELSPIN_TARGET_RATE = *(float*)0x8D3498;
-float& CVehicle::WHEELSPIN_INAIR_TARGET_RATE = *(float*)0x8D349C;
-float& CVehicle::WHEELSPIN_RISE_RATE = *(float*)0x8D34A0;
-float& CVehicle::WHEELSPIN_FALL_RATE = *(float*)0x8D34A4;
-float& CVehicle::m_fAirResistanceMult = *(float*)0x8D34A8;
-float& CVehicle::ms_fRailTrackResistance = *(float*)0x8D34AC;
-float& CVehicle::ms_fRailTrackResistanceDefault = *(float*)0x8D34B0;
+float& CVehicle::WHEELSPIN_TARGET_RATE = *(float*)0x8D3498;          // 1.0f
+float& CVehicle::WHEELSPIN_INAIR_TARGET_RATE = *(float*)0x8D349C;    // 10.0f
+float& CVehicle::WHEELSPIN_RISE_RATE = *(float*)0x8D34A0;            // 0.95f
+float& CVehicle::WHEELSPIN_FALL_RATE = *(float*)0x8D34A4;            // 0.7f
+float& CVehicle::m_fAirResistanceMult = *(float*)0x8D34A8;           // 2.5f
+float& CVehicle::ms_fRailTrackResistance = *(float*)0x8D34AC;        // 0.003f
+float& CVehicle::ms_fRailTrackResistanceDefault = *(float*)0x8D34B0; // 0.003f
 bool& CVehicle::bDisableRemoteDetonation = *(bool*)0xC1CC00;
 bool& CVehicle::bDisableRemoteDetonationOnContact = *(bool*)0xC1CC01;
 bool& CVehicle::m_bEnableMouseSteering = *(bool*)0xC1CC02;
 bool& CVehicle::m_bEnableMouseFlying = *(bool*)0xC1CC03;
 int32& CVehicle::m_nLastControlInput = *(int32*)0xC1CC04;
-CColModel** CVehicle::m_aSpecialColVehicle = (CColModel * *)0xC1CC08;
+CColModel* (&CVehicle::m_aSpecialColVehicle)[4] = *(CColModel*(*)[4])0xC1CC08;
 bool& CVehicle::ms_forceVehicleLightsOff = *(bool*)0xC1CC18;
 bool& CVehicle::s_bPlaneGunsEjectShellCasings = *(bool*)0xC1CC19;
 CColModel (&CVehicle::m_aSpecialColModel)[4] = *(CColModel(*)[4])0xC1CC78;
-tHydrualicData(&CVehicle::m_aSpecialHydraulicData)[4] = *(tHydrualicData(*)[4])0xC1CB60;
+tHydraulicData (&CVehicle::m_aSpecialHydraulicData)[4] = *(tHydraulicData(*)[4])0xC1CB60;
 
-float& fBurstTyreMod = *(float*)0x8D34B4;
-float& fBurstSpeedMax = *(float*)0x8D34B8;
-float& CAR_NOS_EXTRA_SKID_LOSS = *(float*)0x8D34BC;
-float& WS_TRAC_FRAC_LIMIT = *(float*)0x8D34C0;
-float& WS_ALREADY_SPINNING_LOSS = *(float*)0x8D34C4;
-float& fBurstBikeTyreMod = *(float*)0x8D34C8;
-float& fBurstBikeSpeedMax = *(float*)0x8D34CC;
-float& fTweakBikeWheelTurnForce = *(float*)0x8D34D0;
-float& AUTOGYRO_ROTORSPIN_MULT = *(float*)0x8D34D4;
-float& AUTOGYRO_ROTORSPIN_MULTLIMIT = *(float*)0x8D34D8;
-float& AUTOGYRO_ROTORSPIN_DAMP = *(float*)0x8D34DC;
-float& AUTOGYRO_ROTORLIFT_MULT = *(float*)0x8D34E0;
-float& AUTOGYRO_ROTORLIFT_FALLOFF = *(float*)0x8D34E4;
-float& AUTOGYRO_ROTORTILT_ANGLE = *(float*)0x8D34E8;
-float& ROTOR_SEMI_THICKNESS = *(float*)0x8D34EC;
-float* fSpeedMult = (float*)0x8D34F8;
-float& fDamagePosSpeedShift = *(float*)0x8D3510;
-float& DIFF_LIMIT = *(float*)0x8D35B4;
-float& DIFF_SPRING_MULT_X = *(float*)0x8D35B8;
-float& DIFF_SPRING_MULT_Y = *(float*)0x8D35BC;
-float& DIFF_SPRING_MULT_Z = *(float*)0x8D35C0;
-float& DIFF_SPRING_COMPRESS_MULT = *(float*)0x8D35C4;
-CVector* VehicleGunOffset = (CVector*)0x8D35D4;
+float& fBurstTyreMod = *(float*)0x8D34B4;                // 0.13f
+float& fBurstSpeedMax = *(float*)0x8D34B8;               // 0.3f
+float& CAR_NOS_EXTRA_SKID_LOSS = *(float*)0x8D34BC;      // 0.9f
+float& WS_TRAC_FRAC_LIMIT = *(float*)0x8D34C0;           // 0.3f
+float& WS_ALREADY_SPINNING_LOSS = *(float*)0x8D34C4;     // 0.2f
+float& fBurstBikeTyreMod = *(float*)0x8D34C8;            // 0.05f
+float& fBurstBikeSpeedMax = *(float*)0x8D34CC;           // 0.12f
+float& fTweakBikeWheelTurnForce = *(float*)0x8D34D0;     // 2.0f
+float& AUTOGYRO_ROTORSPIN_MULT = *(float*)0x8D34D4;      // 0.006f
+float& AUTOGYRO_ROTORSPIN_MULTLIMIT = *(float*)0x8D34D8; // 0.25f
+float& AUTOGYRO_ROTORSPIN_DAMP = *(float*)0x8D34DC;      // 0.997f
+float& AUTOGYRO_ROTORLIFT_MULT = *(float*)0x8D34E0;      // 4.5f
+float& AUTOGYRO_ROTORLIFT_FALLOFF = *(float*)0x8D34E4;   // 0.75f
+float& AUTOGYRO_ROTORTILT_ANGLE = *(float*)0x8D34E8;     // 0.25f
+float& ROTOR_SEMI_THICKNESS = *(float*)0x8D34EC;         // 0.05f
+float* fSpeedMult = (float*)0x8D34F8;                    // float fSpeedMult[5] = { 0.8f, 0.75f, 0.85f, 0.9f, 0.85f, 0.85f }
+float& fDamagePosSpeedShift = *(float*)0x8D3510;         // 0.4f
+float& DIFF_LIMIT = *(float*)0x8D35B4;                   // 0.8f
+float& DIFF_SPRING_MULT_X = *(float*)0x8D35B8;           // 0.05f
+float& DIFF_SPRING_MULT_Y = *(float*)0x8D35BC;           // 0.05f
+float& DIFF_SPRING_MULT_Z = *(float*)0x8D35C0;           // 0.1f
+float& DIFF_SPRING_COMPRESS_MULT = *(float*)0x8D35C4;    // 2.0f
+CVector (&VehicleGunOffset)[14] = *(CVector(*)[14])0x8D35D4; // maybe [12]
+
 char*& HandlingFilename = *(char**)0x8D3970;
-char(*VehicleNames)[14] = (char(*)[14])0x8D3978;
+char (*VehicleNames)[14] = (char (*)[14])0x8D3978;
 
 void CVehicle::InjectHooks()
 {
@@ -94,12 +95,15 @@ void CVehicle::InjectHooks()
     RH_ScopedInstall(ChangeLawEnforcerState, 0x6D2330);
     RH_ScopedInstall(GetVehicleAppearance, 0x6D1080);
     RH_ScopedInstall(DoHeadLightBeam, 0x6E0E20);
-
+    RH_ScopedInstall(GetPlaneNumGuns, 0x6D3F30);
 }
 
+// 0x6D5F10
 CVehicle::CVehicle(eVehicleCreatedBy createdBy) : CPhysical(), m_vehicleAudio(), m_autoPilot()
 {
-    //plugin::CallMethod<0x6D5F10, CVehicle*, uint8>(this, createdBy);
+    // plugin::CallMethod<0x6D5F10, CVehicle*, uint8>(this, createdBy);
+    // return;
+
     m_bHasPreRenderEffects = true;
     m_nType = ENTITY_TYPE_VEHICLE;
 
@@ -211,14 +215,15 @@ CVehicle::CVehicle(eVehicleCreatedBy createdBy) : CPhysical(), m_vehicleAudio(),
     m_nVehicleWeaponInUse = 0;
     m_fDirtLevel = (float)((rand() % 15));
     m_nCreationTime = CTimer::GetTimeInMS();
-    CVehicle::SetCollisionLighting(0x48);
+    SetCollisionLighting(0x48);
 }
 
+// 0x6E2B40
 CVehicle::~CVehicle()
 {
     CReplay::RecordVehicleDeleted(this);
     m_nAlarmState = 0;
-    CVehicle::DeleteRwObject();
+    DeleteRwObject();
     CRadar::ClearBlipForEntity(eBlipType::BLIP_CAR, CPools::ms_pVehiclePool->GetRef(this));
 
     if (m_pDriver)
@@ -249,7 +254,7 @@ CVehicle::~CVehicle()
 
     if (m_vehicleSpecialColIndex > -1)
     {
-        CVehicle::m_aSpecialColVehicle[m_vehicleSpecialColIndex] = nullptr;
+        m_aSpecialColVehicle[m_vehicleSpecialColIndex] = nullptr;
         m_vehicleSpecialColIndex = -1;
     }
 
@@ -576,7 +581,7 @@ void CVehicle::PreRender_Reversed()
     m_renderLights.m_bLeftRear = false;
 
     const auto fCoeff = CPhysical::GetLightingFromCol(false) * 0.4F;
-    CModelInfo::GetModelInfo(m_nModelIndex)->AsVehicleModelInfoPtr()->SetEnvMapCoeff(fCoeff);
+    GetVehicleModelInfo()->SetEnvMapCoeff(fCoeff);
 }
 
 void CVehicle::Render()
@@ -585,9 +590,9 @@ void CVehicle::Render()
 }
 void CVehicle::Render_Reversed()
 {
-    auto* vehicleMI = CModelInfo::GetModelInfo(m_nModelIndex)->AsVehicleModelInfoPtr();
+    auto* mi = GetVehicleModelInfo();
     const auto iDirtLevel = static_cast<int32>(m_fDirtLevel) & 0xF;
-    CVehicleModelInfo::SetDirtTextures(vehicleMI, iDirtLevel);
+    CVehicleModelInfo::SetDirtTextures(mi, iDirtLevel);
 
     CEntity::Render();
 }
@@ -1160,12 +1165,12 @@ void CVehicle::Shutdown()
 // 0x6D0B70
 int32 CVehicle::GetRemapIndex()
 {
-    auto* modelInfo = CModelInfo::GetModelInfo(m_nModelIndex)->AsVehicleModelInfoPtr();
-    if (modelInfo->GetNumRemaps() <= 0)
+    auto* mi = GetVehicleModelInfo();
+    if (mi->GetNumRemaps() <= 0)
         return -1;
 
-    for (auto i = 0; i < modelInfo->GetNumRemaps(); ++i)
-        if (modelInfo->m_anRemapTxds[i] == m_nPreviousRemapTxd)
+    for (auto i = 0; i < mi->GetNumRemaps(); ++i)
+        if (mi->m_anRemapTxds[i] == m_nPreviousRemapTxd)
             return i;
 
     return -1;
@@ -1203,7 +1208,7 @@ void CVehicle::SetRemap(int32 remapIndex)
     }
     else
     {
-        auto const infoRemapInd = CModelInfo::GetModelInfo(m_nModelIndex)->AsVehicleModelInfoPtr()->m_anRemapTxds[remapIndex];
+        auto const infoRemapInd = GetVehicleModelInfo()->m_anRemapTxds[remapIndex];
         if (infoRemapInd == m_nPreviousRemapTxd)
             return;
 
@@ -1825,7 +1830,22 @@ float CVehicle::GetPlaneGunsAutoAimAngle()
 // 0x6D3F30
 int32 CVehicle::GetPlaneNumGuns()
 {
-    return ((int32(__thiscall*)(CVehicle*))0x6D3F30)(this);
+    switch (m_nModelIndex) {
+    case MODEL_HUNTER:
+    case MODEL_SEASPAR:
+    case MODEL_RCBARON:
+    case MODEL_MAVERICK:
+    case MODEL_POLMAV:
+    case MODEL_CARGOBOB:
+        return 1;
+    case MODEL_RUSTLER:
+        return 6;
+    case MODEL_HYDRA:
+    case MODEL_TORNADO:
+        return 2;
+    default:
+        return 0;
+    }
 }
 
 // 0x6D4010
@@ -2457,8 +2477,8 @@ void CVehicle::AddExhaustParticles()
     {
         return;
     }
-    auto vehicleModelInfo = CModelInfo::GetModelInfo(m_nModelIndex)->AsVehicleModelInfoPtr();
-    CVector firstExhaustPos = vehicleModelInfo->m_pVehicleStruct->m_avDummyPos[DUMMY_EXHAUST];
+    auto mi = GetVehicleModelInfo();
+    CVector firstExhaustPos = mi->m_pVehicleStruct->m_avDummyPos[DUMMY_EXHAUST];
     CVector secondExhaustPos = firstExhaustPos;
     secondExhaustPos.x *= -1.0f;
     CMatrix entityMatrix (*m_matrix);
@@ -2475,7 +2495,7 @@ void CVehicle::AddExhaustParticles()
             break;
         case MODEL_NRG500:
             if (!m_anExtras[0] || m_anExtras[0] == 1)
-                secondExhaustPos = vehicleModelInfo->m_pVehicleStruct->m_avDummyPos[DUMMY_EXHAUST_SECONDARY];
+                secondExhaustPos = mi->m_pVehicleStruct->m_avDummyPos[DUMMY_EXHAUST_SECONDARY];
             break;
         case MODEL_BF400:
             if (m_anExtras[0] == 2)
@@ -2520,44 +2540,45 @@ void CVehicle::AddExhaustParticles()
             FxPrtMult_c fxPrt(0.9f, 0.9f, 1.0f, particleAlpha, 0.2f, 1.0f, fLife);
             int32 numExhausts = 2;
             for (int32 i = 0; i < 2; i++) {
-                FxSystem_c* pFirstExhaustFxSystem = g_fx.m_pPrtSmokeII3expand;
+                FxSystem_c* firstExhaustFxSystem = g_fx.m_pPrtSmokeII3expand;
                 if (bFirstExhaustSubmergedInWater) {
                     fxPrt.m_color.alpha = particleAlpha * 0.5f;
                     fxPrt.m_fSize = 0.6f;
-                    pFirstExhaustFxSystem = g_fx.m_pPrtBubble;
+                    firstExhaustFxSystem = g_fx.m_pPrtBubble;
                 }
-                pFirstExhaustFxSystem->AddParticle(&firstExhaustPos, &vecParticleVelocity, 0.0f, &fxPrt, -1.0f, m_fContactSurfaceBrightness, 0.6f, 0);
+                firstExhaustFxSystem->AddParticle(&firstExhaustPos, &vecParticleVelocity, 0.0f, &fxPrt, -1.0f, m_fContactSurfaceBrightness, 0.6f, 0);
                 if (bHasDoubleExhaust) {
-                    FxSystem_c* pSecondExhaustFxSystem = g_fx.m_pPrtSmokeII3expand;
+                    FxSystem_c* secondExhaustFxSystem = g_fx.m_pPrtSmokeII3expand;
                     if (bSecondExhaustSubmergedInWater)
                     {
                         fxPrt.m_color.alpha = particleAlpha * 0.5f;
                         fxPrt.m_fSize = 0.6f;
-                        pSecondExhaustFxSystem = g_fx.m_pPrtBubble;
+                        secondExhaustFxSystem = g_fx.m_pPrtBubble;
                     }
-                    pSecondExhaustFxSystem->AddParticle(&secondExhaustPos, &vecParticleVelocity, 0.0f, &fxPrt, -1.0f, m_fContactSurfaceBrightness, 0.6f, 0);
+                    secondExhaustFxSystem->AddParticle(&secondExhaustPos, &vecParticleVelocity, 0.0f, &fxPrt, -1.0f, m_fContactSurfaceBrightness, 0.6f, 0);
                 }
+
                 if (m_fGasPedal > 0.5f && m_nCurrentGear < 3) {
                     if (rand() % 2) {
-                        FxSystem_c* pSecondaryExhaustFxSystem = g_fx.m_pPrtSmokeII3expand;
+                        FxSystem_c* secondaryExhaustFxSystem = g_fx.m_pPrtSmokeII3expand;
                         if (bFirstExhaustSubmergedInWater)
                         {
                             fxPrt.m_color.alpha = particleAlpha * 0.5f;
                             fxPrt.m_fSize = 0.6f;
-                            pSecondaryExhaustFxSystem = g_fx.m_pPrtBubble;
+                            secondaryExhaustFxSystem = g_fx.m_pPrtBubble;
                         }
-                        pSecondaryExhaustFxSystem->AddParticle(&firstExhaustPos, &vecParticleVelocity, 0.0f, &fxPrt, -1.0f, m_fContactSurfaceBrightness, 0.6f, 0);
+                        secondaryExhaustFxSystem->AddParticle(&firstExhaustPos, &vecParticleVelocity, 0.0f, &fxPrt, -1.0f, m_fContactSurfaceBrightness, 0.6f, 0);
                     }
                     else if (bHasDoubleExhaust)
                     {
-                        FxSystem_c* pSecondaryExhaustFxSystem = g_fx.m_pPrtSmokeII3expand;
+                        FxSystem_c* secondaryExhaustFxSystem = g_fx.m_pPrtSmokeII3expand;
                         if (bSecondExhaustSubmergedInWater)
                         {
                             fxPrt.m_color.alpha = particleAlpha * 0.5f;
                             fxPrt.m_fSize = 0.6f;
-                            pSecondaryExhaustFxSystem = g_fx.m_pPrtBubble;
+                            secondaryExhaustFxSystem = g_fx.m_pPrtBubble;
                         }
-                        pSecondaryExhaustFxSystem->AddParticle(&secondExhaustPos, &vecParticleVelocity, 0.0f, &fxPrt, -1.0f, m_fContactSurfaceBrightness, 0.6f, 0);
+                        secondaryExhaustFxSystem->AddParticle(&secondExhaustPos, &vecParticleVelocity, 0.0f, &fxPrt, -1.0f, m_fContactSurfaceBrightness, 0.6f, 0);
                     }
                 }
             }

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -63,7 +63,7 @@ char (*VehicleNames)[14] = (char (*)[14])0x8D3978;
 void CVehicle::InjectHooks()
 {
     RH_ScopedClass(CVehicle);
-    RH_ScopedCategory("Vehicle/Ped");
+    RH_ScopedCategory("Vehicle");
 
     RH_ScopedInstall(SetModelIndex_Reversed, 0x6D6A40);
     RH_ScopedInstall(DeleteRwObject_Reversed, 0x6D6410);
@@ -209,12 +209,12 @@ CVehicle::CVehicle(eVehicleCreatedBy createdBy) : CPhysical(), m_vehicleAudio(),
     m_pDustParticle = nullptr;
     m_pCustomCarPlate = nullptr;
 
-    memset(m_anUpgrades, 0xFFu, sizeof(m_anUpgrades));
+    memset(m_anUpgrades, 255, sizeof(m_anUpgrades));
     m_fWheelScale = 1.0f;
     m_nWindowsOpenFlags = 0;
     m_nNitroBoosts = 0;
     m_nHasslePosId = 0;
-    m_nVehicleWeaponInUse = 0;
+    m_nVehicleWeaponInUse = CAR_WEAPON_NOT_USED;
     m_fDirtLevel = (float)((rand() % 15));
     m_nCreationTime = CTimer::GetTimeInMS();
     SetCollisionLighting(0x48);
@@ -328,19 +328,19 @@ void CVehicle::SetModelIndex_Reversed(uint32 index)
         break;
     }
 
-    //Set up weapons
+    // Set up weapons
     switch (m_nModelIndex)
     {
     case MODEL_RUSTLER:
     case MODEL_STUNT:
-        m_nVehicleWeaponInUse = eCarWeapon::CAR_WEAPON_HEAVY_GUN;
+        m_nVehicleWeaponInUse = CAR_WEAPON_HEAVY_GUN;
         break;
     case MODEL_BEAGLE:
-        m_nVehicleWeaponInUse = eCarWeapon::CAR_WEAPON_FREEFALL_BOMB;
+        m_nVehicleWeaponInUse = CAR_WEAPON_FREEFALL_BOMB;
         break;
     case MODEL_HYDRA:
     case MODEL_TORNADO:
-        m_nVehicleWeaponInUse = eCarWeapon::CAR_WEAPON_LOCK_ON_ROCKET;
+        m_nVehicleWeaponInUse = CAR_WEAPON_LOCK_ON_ROCKET;
         break;
     }
 }

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -2135,9 +2135,9 @@ void CVehicle::BladeColSectorList(CPtrList& ptrList, CColModel& colModel, CMatri
 }
 
 // 0x6DBA30
-void CVehicle::SetComponentRotation(RwFrame* component, int32 axis, float angle, bool bResetPosition)
+void CVehicle::SetComponentRotation(RwFrame* component, eRotationAxis axis, float angle, bool bResetPosition)
 {
-    plugin::CallMethod<0x6DBA30, CVehicle*, RwFrame*, int32, float, bool>(this, component, axis, angle, bResetPosition);
+    plugin::CallMethod<0x6DBA30, CVehicle*, RwFrame*, eRotationAxis, float, bool>(this, component, axis, angle, bResetPosition);
 }
 
 // 0x6DBBB0

--- a/source/game_sa/Entity/Vehicle/Vehicle.h
+++ b/source/game_sa/Entity/Vehicle/Vehicle.h
@@ -28,7 +28,7 @@ class CPed;
 class CPlane;
 class CHeli;
 
-enum eCarWeapon {
+enum eCarWeapon : uint8 {
     CAR_WEAPON_NOT_USED,
     CAR_WEAPON_HEAVY_GUN,
     CAR_WEAPON_FREEFALL_BOMB,
@@ -337,7 +337,7 @@ public:
     char            field_510;             // not used?
     char            field_511;             // initialised, but not used?
     char            field_512;             // initialised, but not used?
-    char            m_nVehicleWeaponInUse; // see enum eCarWeapon
+    eCarWeapon      m_nVehicleWeaponInUse;
     uint32          m_nHornCounter;
     char            field_518;       // random id related to siren
     char            m_nCarHornTimer; // car horn related

--- a/source/game_sa/Entity/Vehicle/Vehicle.h
+++ b/source/game_sa/Entity/Vehicle/Vehicle.h
@@ -105,7 +105,7 @@ enum eCarPiece {
     CAR_PIECE_WINDSCREEN = 19,
 };
 
-enum eRotationAxis {
+enum eRotationAxis : int32 {
     AXIS_X = 0,
     AXIS_Y = 1,
     AXIS_Z = 2
@@ -566,7 +566,7 @@ public:
     void FlyingControl(eFlightModel flightModel, float leftRightSkid, float steeringUpDown, float steeringLeftRight, float accelerationBreakStatus);
     // always return false?
     void BladeColSectorList(CPtrList& ptrList, CColModel& colModel, CMatrix& matrix, int16 arg3, float arg4);
-    void SetComponentRotation(RwFrame* component, int32 axis, float angle, bool bResetPosition); // rotation axis: eRotationAxis
+    void SetComponentRotation(RwFrame* component, eRotationAxis axis, float angle, bool bResetPosition); // rotation axis: eRotationAxis
     void SetTransmissionRotation(RwFrame* component, float arg1, float arg2, CVector posn, bool isFront);
     void ProcessBoatControl(tBoatHandlingData* boatHandling, float* fWaterResistance, bool bCollidedWithWorld, bool bPostCollision);
     void DoBoatSplashes(float fWaterDamping);

--- a/source/game_sa/Entity/Vehicle/Vehicle.h
+++ b/source/game_sa/Entity/Vehicle/Vehicle.h
@@ -129,7 +129,7 @@ enum tWheelState : int32 {
     WHEEL_STATE_FIXED,	  // not rotating
 };
 
-struct tHydrualicData {
+struct tHydraulicData {
     // applied when the vehicle is moving
     // or when hopping keys are pressed (numpad keys)
     float m_fSuspensionNormalUpperLimit;
@@ -144,18 +144,12 @@ struct tHydrualicData {
     // and does NOT apply if numpad keys are pressed (car hopping)
     float m_fSuspensionNormalIdleUpperLimit;
     float m_fSuspensionNormalIdleLowerLimit;
-    float m_wheelSuspension[4];
+    float m_aWheelSuspension[4];
 };
 
-VALIDATE_SIZE(tHydrualicData, 0x28);
+VALIDATE_SIZE(tHydraulicData, 0x28);
 
 class CVehicle : public CPhysical {
-public:
-    CVehicle(plugin::dummy_func_t) : CPhysical() {} //TODO: Remove
-    CVehicle(eVehicleCreatedBy createdBy);
-    ~CVehicle() override;
-    static void* operator new(uint32 size);
-    static void operator delete(void* data);
 public:
     CAEVehicleAudioEntity m_vehicleAudio;
     tHandlingData*        m_pHandlingData;
@@ -372,28 +366,32 @@ public:
     int16        m_nRemapTxd;
     RwTexture*   m_pRemapTexture;
 
-    static float &WHEELSPIN_TARGET_RATE; // 1.0
-    static float &WHEELSPIN_INAIR_TARGET_RATE; // 10.0
-    static float &WHEELSPIN_RISE_RATE; // 0.95
-    static float &WHEELSPIN_FALL_RATE; // 0.7
-    static float &m_fAirResistanceMult; // 2.5
-    static float &ms_fRailTrackResistance; // 0.003
-    static float &ms_fRailTrackResistanceDefault; // 0.003
+    static float &WHEELSPIN_TARGET_RATE;
+    static float &WHEELSPIN_INAIR_TARGET_RATE;
+    static float &WHEELSPIN_RISE_RATE;
+    static float &WHEELSPIN_FALL_RATE;
+    static float &m_fAirResistanceMult;
+    static float &ms_fRailTrackResistance;
+    static float &ms_fRailTrackResistanceDefault;
     static bool &bDisableRemoteDetonation;
     static bool &bDisableRemoteDetonationOnContact;
     static bool &m_bEnableMouseSteering;
     static bool &m_bEnableMouseFlying;
     static int32 &m_nLastControlInput;
-    static CColModel **m_aSpecialColVehicle; // CColModel *CVehicle::m_aSpecialColVehicle[4]
+    static CColModel* (&m_aSpecialColVehicle)[4];
     static bool &ms_forceVehicleLightsOff;
     static bool &s_bPlaneGunsEjectShellCasings;
-    static CColModel (&m_aSpecialColModel)[4]; // static CColModel m_aSpecialColModel[4]
-    static tHydrualicData(&m_aSpecialHydraulicData)[4];
+    static CColModel (&m_aSpecialColModel)[4];
+    static tHydraulicData(&m_aSpecialHydraulicData)[4];
 
 public:
-    static void InjectHooks();
+    CVehicle(plugin::dummy_func_t) : CPhysical() { /* todo: remove NOTSA */ }
+    CVehicle(eVehicleCreatedBy createdBy);
+    ~CVehicle() override;
 
-// VIRTUAL
+    static void* operator new(uint32 size);
+    static void operator delete(void* data);
+
     void SetModelIndex(uint32 index) override;
     void DeleteRwObject() override;
     void SpecialEntityPreCollisionStuff(CPhysical* colPhysical, bool bIgnoreStuckCheck, bool& bCollisionDisabled, bool& bCollidedEntityCollisionIgnored, bool& bCollidedEntityUnableToMove, bool& bThisOrCollidedEntityStuck) override;
@@ -454,33 +452,6 @@ public:
     virtual bool Save();
     virtual bool Load();
 
-// VIRTUAL METHODS REVERSED
-private:
-    void SetModelIndex_Reversed(uint32 index);
-    void DeleteRwObject_Reversed();
-    void SpecialEntityPreCollisionStuff_Reversed(CPhysical* colPhysical,
-                                                 bool bIgnoreStuckCheck,
-                                                 bool& bCollisionDisabled,
-                                                 bool& bCollidedEntityCollisionIgnored,
-                                                 bool& bCollidedEntityUnableToMove,
-                                                 bool& bThisOrCollidedEntityStuck);
-    uint8 SpecialEntityCalcCollisionSteps_Reversed(bool& bProcessCollisionBeforeSettingTimeStep, bool& unk2);
-    void PreRender_Reversed();
-    void Render_Reversed();
-    bool SetupLighting_Reversed();
-    void RemoveLighting_Reversed(bool bRemove);
-    void ProcessOpenDoor_Reversed(CPed* ped, uint32 doorComponentId, uint32 animGroup, uint32 animId, float fTime);
-    void ProcessDrivingAnims_Reversed(CPed* driver, uint8 bBlend);
-    float GetHeightAboveRoad_Reversed();
-    bool CanPedStepOutCar_Reversed(bool bIgnoreSpeedUpright);
-    bool CanPedJumpOutCar_Reversed(CPed* ped);
-    bool GetTowHitchPos_Reversed(CVector& outPos, bool bCheckModelInfo, CVehicle* veh);
-    bool GetTowBarPos_Reversed(CVector& outPos, bool bCheckModelInfo, CVehicle* veh);
-    bool Save_Reversed();
-    bool Load_Reversed();
-
- // CLASS FUNCS
-public:
     // -1 if no remap index
     int32 GetRemapIndex();
     void SetRemapTexDictionary(int32 txdId);
@@ -633,46 +604,45 @@ public:
 
     bool AreAnyOfPassengersFollowerOfGroup(const CPedGroup& group);
 
-// STATIC FUNCS
     static void Shutdown();
     static void SetComponentAtomicAlpha(RpAtomic* atomic, int32 alpha);
 
 public:
     // m_nVehicleType start
-    bool IsVehicleTypeValid()     const { return m_nVehicleType != VEHICLE_TYPE_IGNORE; }
-    bool IsAutomobile()           const { return m_nVehicleType == VEHICLE_TYPE_AUTOMOBILE; }
-    bool IsMonsterTruck()         const { return m_nVehicleType == VEHICLE_TYPE_MTRUCK; }
-    bool IsQuad()                 const { return m_nVehicleType == VEHICLE_TYPE_QUAD; }
-    bool IsHeli()                 const { return m_nVehicleType == VEHICLE_TYPE_HELI; }
-    bool IsPlane()                const { return m_nVehicleType == VEHICLE_TYPE_PLANE; }
-    bool IsBoat()                 const { return m_nVehicleType == VEHICLE_TYPE_BOAT; }
-    bool IsTrain()                const { return m_nVehicleType == VEHICLE_TYPE_TRAIN; }
-    bool IsFakeAircraft()         const { return m_nVehicleType == VEHICLE_TYPE_FHELI || m_nVehicleType == VEHICLE_TYPE_FPLANE; }
-    bool IsBike()                 const { return m_nVehicleType == VEHICLE_TYPE_BIKE; }
-    bool IsBMX()                  const { return m_nVehicleType == VEHICLE_TYPE_BMX; }
-    bool IsTrailer()              const { return m_nVehicleType == VEHICLE_TYPE_TRAILER; }
+    [[nodiscard]] bool IsVehicleTypeValid()     const { return m_nVehicleType != VEHICLE_TYPE_IGNORE; }
+    [[nodiscard]] bool IsAutomobile()           const { return m_nVehicleType == VEHICLE_TYPE_AUTOMOBILE; }
+    [[nodiscard]] bool IsMonsterTruck()         const { return m_nVehicleType == VEHICLE_TYPE_MTRUCK; }
+    [[nodiscard]] bool IsQuad()                 const { return m_nVehicleType == VEHICLE_TYPE_QUAD; }
+    [[nodiscard]] bool IsHeli()                 const { return m_nVehicleType == VEHICLE_TYPE_HELI; }
+    [[nodiscard]] bool IsPlane()                const { return m_nVehicleType == VEHICLE_TYPE_PLANE; }
+    [[nodiscard]] bool IsBoat()                 const { return m_nVehicleType == VEHICLE_TYPE_BOAT; }
+    [[nodiscard]] bool IsTrain()                const { return m_nVehicleType == VEHICLE_TYPE_TRAIN; }
+    [[nodiscard]] bool IsFakeAircraft()         const { return m_nVehicleType == VEHICLE_TYPE_FHELI || m_nVehicleType == VEHICLE_TYPE_FPLANE; }
+    [[nodiscard]] bool IsBike()                 const { return m_nVehicleType == VEHICLE_TYPE_BIKE; }
+    [[nodiscard]] bool IsBMX()                  const { return m_nVehicleType == VEHICLE_TYPE_BMX; }
+    [[nodiscard]] bool IsTrailer()              const { return m_nVehicleType == VEHICLE_TYPE_TRAILER; }
     // m_nVehicleType end
 
     // m_nVehicleSubType start
-    bool IsSubVehicleTypeValid() const { return m_nVehicleSubType != VEHICLE_TYPE_IGNORE; }
-    bool IsSubAutomobile()       const { return m_nVehicleSubType == VEHICLE_TYPE_AUTOMOBILE; }
-    bool IsSubMonsterTruck()     const { return m_nVehicleSubType == VEHICLE_TYPE_MTRUCK; }
-    bool IsSubQuad()             const { return m_nVehicleSubType == VEHICLE_TYPE_QUAD; }
-    bool IsSubHeli()             const { return m_nVehicleSubType == VEHICLE_TYPE_HELI; }
-    bool IsSubPlane()            const { return m_nVehicleSubType == VEHICLE_TYPE_PLANE; }
-    bool IsSubBoat()             const { return m_nVehicleSubType == VEHICLE_TYPE_BOAT; }
-    bool IsSubTrain()            const { return m_nVehicleSubType == VEHICLE_TYPE_TRAIN; }
-    bool IsSubFakeAircraft()     const { return m_nVehicleSubType == VEHICLE_TYPE_FHELI || m_nVehicleSubType == VEHICLE_TYPE_FPLANE; }
-    bool IsSubBike()             const { return m_nVehicleSubType == VEHICLE_TYPE_BIKE; }
-    bool IsSubBMX()              const { return m_nVehicleSubType == VEHICLE_TYPE_BMX; }
-    bool IsSubTrailer()          const { return m_nVehicleSubType == VEHICLE_TYPE_TRAILER; }
+    [[nodiscard]] bool IsSubVehicleTypeValid() const { return m_nVehicleSubType != VEHICLE_TYPE_IGNORE; }
+    [[nodiscard]] bool IsSubAutomobile()       const { return m_nVehicleSubType == VEHICLE_TYPE_AUTOMOBILE; }
+    [[nodiscard]] bool IsSubMonsterTruck()     const { return m_nVehicleSubType == VEHICLE_TYPE_MTRUCK; }
+    [[nodiscard]] bool IsSubQuad()             const { return m_nVehicleSubType == VEHICLE_TYPE_QUAD; }
+    [[nodiscard]] bool IsSubHeli()             const { return m_nVehicleSubType == VEHICLE_TYPE_HELI; }
+    [[nodiscard]] bool IsSubPlane()            const { return m_nVehicleSubType == VEHICLE_TYPE_PLANE; }
+    [[nodiscard]] bool IsSubBoat()             const { return m_nVehicleSubType == VEHICLE_TYPE_BOAT; }
+    [[nodiscard]] bool IsSubTrain()            const { return m_nVehicleSubType == VEHICLE_TYPE_TRAIN; }
+    [[nodiscard]] bool IsSubFakeAircraft()     const { return m_nVehicleSubType == VEHICLE_TYPE_FHELI || m_nVehicleSubType == VEHICLE_TYPE_FPLANE; }
+    [[nodiscard]] bool IsSubBike()             const { return m_nVehicleSubType == VEHICLE_TYPE_BIKE; }
+    [[nodiscard]] bool IsSubBMX()              const { return m_nVehicleSubType == VEHICLE_TYPE_BMX; }
+    [[nodiscard]] bool IsSubTrailer()          const { return m_nVehicleSubType == VEHICLE_TYPE_TRAILER; }
 
-    bool IsSubRoadVehicle()      const { return !IsSubHeli() && !IsSubPlane() && !IsSubTrain(); }
+    [[nodiscard]] bool IsSubRoadVehicle()      const { return !IsSubHeli() && !IsSubPlane() && !IsSubTrain(); }
     // m_nVehicleSubType end
 
-    bool IsTransportVehicle()    const { return m_nModelIndex == MODEL_TAXI    || m_nModelIndex == MODEL_CABBIE; }
-    bool IsAmphibiousHeli()      const { return m_nModelIndex == MODEL_SEASPAR || m_nModelIndex == MODEL_LEVIATHN; }
-    bool IsConstructionVehicle() const { return m_nModelIndex == MODEL_DUMPER  || m_nModelIndex == MODEL_DOZER || m_nModelIndex == MODEL_FORKLIFT; }
+    [[nodiscard]] bool IsTransportVehicle()    const { return m_nModelIndex == MODEL_TAXI    || m_nModelIndex == MODEL_CABBIE; }
+    [[nodiscard]] bool IsAmphibiousHeli()      const { return m_nModelIndex == MODEL_SEASPAR || m_nModelIndex == MODEL_LEVIATHN; }
+    [[nodiscard]] bool IsConstructionVehicle() const { return m_nModelIndex == MODEL_DUMPER  || m_nModelIndex == MODEL_DOZER || m_nModelIndex == MODEL_FORKLIFT; }
 
     eVehicleCreatedBy GetCreatedBy()      { return m_nCreatedBy; }
     bool IsCreatedBy(eVehicleCreatedBy v) { return v == m_nCreatedBy; }
@@ -690,6 +660,33 @@ public:
     // if bWorldSpace is true, returns the position in world-space
     // otherwise in model-space
     CVector GetDummyPosition(eVehicleDummies dummy, bool bWorldSpace = true);
+
+private:
+    friend void InjectHooksMain();
+    static void InjectHooks();
+
+    void SetModelIndex_Reversed(uint32 index);
+    void DeleteRwObject_Reversed();
+    void SpecialEntityPreCollisionStuff_Reversed(CPhysical* colPhysical,
+                                                 bool bIgnoreStuckCheck,
+                                                 bool& bCollisionDisabled,
+                                                 bool& bCollidedEntityCollisionIgnored,
+                                                 bool& bCollidedEntityUnableToMove,
+                                                 bool& bThisOrCollidedEntityStuck);
+    uint8 SpecialEntityCalcCollisionSteps_Reversed(bool& bProcessCollisionBeforeSettingTimeStep, bool& unk2);
+    void PreRender_Reversed();
+    void Render_Reversed();
+    bool SetupLighting_Reversed();
+    void RemoveLighting_Reversed(bool bRemove);
+    void ProcessOpenDoor_Reversed(CPed* ped, uint32 doorComponentId, uint32 animGroup, uint32 animId, float fTime);
+    void ProcessDrivingAnims_Reversed(CPed* driver, uint8 bBlend);
+    float GetHeightAboveRoad_Reversed();
+    bool CanPedStepOutCar_Reversed(bool bIgnoreSpeedUpright);
+    bool CanPedJumpOutCar_Reversed(CPed* ped);
+    bool GetTowHitchPos_Reversed(CVector& outPos, bool bCheckModelInfo, CVehicle* veh);
+    bool GetTowBarPos_Reversed(CVector& outPos, bool bCheckModelInfo, CVehicle* veh);
+    bool Save_Reversed();
+    bool Load_Reversed();
 };
 VALIDATE_SIZE(CVehicle, 0x5A0);
 
@@ -706,28 +703,17 @@ RwObject* SetVehicleAtomicVisibilityCB(RwObject* object, void* data);
 RwFrame* SetVehicleAtomicVisibilityCB(RwFrame* component, void* data);
 void DestroyVehicleAndDriverAndPassengers(CVehicle* vehicle);
 
-extern float &fBurstTyreMod; // 0.13
-extern float &fBurstSpeedMax; // 0.3
-extern float &CAR_NOS_EXTRA_SKID_LOSS; // 0.9
-extern float &WS_TRAC_FRAC_LIMIT; // 0.3
-extern float &WS_ALREADY_SPINNING_LOSS; // 0.2
-extern float &fBurstBikeTyreMod; // 0.05
-extern float &fBurstBikeSpeedMax; // 0.12
-extern float &fTweakBikeWheelTurnForce; // 2.0
-extern float &AUTOGYRO_ROTORSPIN_MULT; // 0.006
-extern float &AUTOGYRO_ROTORSPIN_MULTLIMIT; // 0.25
-extern float &AUTOGYRO_ROTORSPIN_DAMP; // 0.997
-extern float &AUTOGYRO_ROTORLIFT_MULT; // 4.5
-extern float &AUTOGYRO_ROTORLIFT_FALLOFF; // 0.75
-extern float &AUTOGYRO_ROTORTILT_ANGLE; // 0.25
-extern float &ROTOR_SEMI_THICKNESS; // 0.05
-extern float *fSpeedMult; // float fSpeedMult[5] = {0.8, 0.75, 0.85, 0.9, 0.85, 0.85}
-extern float &fDamagePosSpeedShift; // 0.4
-extern float &DIFF_LIMIT; // 0.8
-extern float &DIFF_SPRING_MULT_X; // 0.05
-extern float &DIFF_SPRING_MULT_Y; // 0.05
-extern float &DIFF_SPRING_MULT_Z; // 0.1
-extern float &DIFF_SPRING_COMPRESS_MULT; // 2.0
-extern CVector *VehicleGunOffset; // CVector VehicleGunOffset[12];
 extern char *&HandlingFilename;
 extern char(*VehicleNames)[14]; // char VehicleNames[100][14]; sorting is based on handling id
+
+/* Missing funcs | from Android
+
+CVehicle::ReduceVehicleDamage(float &);
+CVehicle::CanUseCameraHeightSetting();
+CVehicle::DoReverseLightEffect(int32, CMatrix&, uint8, uint8, uint32, uint8);
+CVehicle::GetNewSteeringAmt();
+void CVehicle::GetGasTankPosition();
+void CVehicle::SetTappedGasTankVehicle(CEntity* entity);
+bool CVehicle::GetHasDualExhausts() { return (m_pHandlingData->m_nModelFlags >> 13) & 1; // m_bNoExhaust }
+*/
+

--- a/source/game_sa/Models/VehicleModelInfo.cpp
+++ b/source/game_sa/Models/VehicleModelInfo.cpp
@@ -136,8 +136,7 @@ CVehicleModelInfo::CVehicleModelInfo() : CClumpModelInfo()
     m_nFlags = 0;
     m_nAnimBlockIndex = -1;
     memset(m_anUpgrades, 0xFF, sizeof(m_anUpgrades));
-    for (int32 i = 0; i < 4; ++i)
-        m_anRemapTxds[i] = -1;
+    std::ranges::fill(m_anRemapTxds, -1);
 }
 
 ModelInfoType CVehicleModelInfo::GetModelType()
@@ -167,13 +166,12 @@ void CVehicleModelInfo::DeleteRwObject()
 }
 void CVehicleModelInfo::DeleteRwObject_Reversed()
 {
-    if (m_pVehicleStruct)
-        delete m_pVehicleStruct;
-
+    delete m_pVehicleStruct;
     m_pVehicleStruct = nullptr;
     CClumpModelInfo::DeleteRwObject();
 }
 
+// 0x4C9680
 RwObject* CVehicleModelInfo::CreateInstance()
 {
     return CVehicleModelInfo::CreateInstance_Reversed();

--- a/source/game_sa/Renderer.cpp
+++ b/source/game_sa/Renderer.cpp
@@ -979,7 +979,7 @@ void CRenderer::ConstructRenderList() {
         float fGroundHeightZ = TheCamera.CalculateGroundHeight(eGroundHeightType::ENTITY_BOUNDINGBOX_BOTTOM);
         if (player->GetPosition().z - fGroundHeightZ > 50.0f) {
             float fGroundHeightZ = TheCamera.CalculateGroundHeight(eGroundHeightType::ENTITY_BOUNDINGBOX_TOP);
-            if (player->GetPosition().z - fGroundHeightZ > 10.0f && FindPlayerVehicle(-1, false))
+            if (player->GetPosition().z - fGroundHeightZ > 10.0f && FindPlayerVehicle())
                 ms_bInTheSky = true;
         }
         const float fCameraZ = TheCamera.GetPosition().z;

--- a/source/game_sa/Renderer.cpp
+++ b/source/game_sa/Renderer.cpp
@@ -570,7 +570,7 @@ int32 CRenderer::SetupEntityVisibility(CEntity* entity, float& outDistance) {
             if (FindPlayerVehicle() == entity && gbFirstPersonRunThisFrame && CReplay::Mode != REPLAY_MODE_1) {
                 uint32 dwDirectionWasLooking = CCamera::GetActiveCamera().m_nDirectionWasLooking;
                 CVehicle* vehicle = FindPlayerVehicle();
-                if (!vehicle->IsBike() || !(vehicle->AsBike()->damageFlags.bDamageFlag8))
+                if (!vehicle->IsBike() || !(vehicle->AsBike()->bikeFlags.bWheelieCam))
                 {
                     if (dwDirectionWasLooking == 3)
                         return RENDERER_CULLED;

--- a/source/game_sa/Streaming.cpp
+++ b/source/game_sa/Streaming.cpp
@@ -3479,7 +3479,7 @@ void CStreaming::StreamVehiclesAndPeds() {
 
 // 0x40B650
 void CStreaming::StreamVehiclesAndPeds_Always(const CVector& unused) {
-    if (CVehicle* vehicle = FindPlayerVehicle(-1, false)) {
+    if (CVehicle* vehicle = FindPlayerVehicle()) {
         switch (vehicle->m_nVehicleSubType) {
         case VEHICLE_TYPE_PLANE:
             return;

--- a/source/game_sa/World.cpp
+++ b/source/game_sa/World.cpp
@@ -1200,7 +1200,7 @@ void CWorld::RemoveFallenCars() {
             if (vehicle->IsCreatedBy(eVehicleCreatedBy::MISSION_VEHICLE) && !vehicle->physicalFlags.bDestroyed)
                 return true;
 
-            if (vehicle == FindPlayerVehicle(-1, false))
+            if (vehicle == FindPlayerVehicle())
                 return true;
 
             return vehicle->m_pDriver && vehicle->m_pDriver->IsPlayer();

--- a/source/toolsmenu/CDebugMenu.cpp
+++ b/source/toolsmenu/CDebugMenu.cpp
@@ -317,19 +317,6 @@ static void DebugCode() {
         printf("");
         CCheat::MoneyArmourHealthCheat();
     }
-    if (pad->IsStandardKeyJustDown('3')) {
-        printf("");
-        auto mi = CModelInfo::GetModelInfo(411)->AsVehicleModelInfoPtr();
-        auto type = mi->m_nVehicleType;
-        CVehicle* vehicle = new CAutomobile(561, RANDOM_VEHICLE, true);
-        vehicle->SetPosn(FindPlayerCoors() + CVector(2.f, 0.0f, 2.0f));
-        CWorld::Add(vehicle);
-    }
-    if (pad->IsStandardKeyJustDown('4')) {
-        CVehicle* vehicle = new CBoat(472, PARKED_VEHICLE);
-        vehicle->SetPosn(FindPlayerCoors() + CVector(2.f, 0.0f, 2.0f));
-        CWorld::Add(vehicle);
-    }
 }
 
 void CDebugMenu::ImguiDrawLoop() {

--- a/source/toolsmenu/CDebugMenu.cpp
+++ b/source/toolsmenu/CDebugMenu.cpp
@@ -317,6 +317,19 @@ static void DebugCode() {
         printf("");
         CCheat::MoneyArmourHealthCheat();
     }
+    if (pad->IsStandardKeyJustDown('3')) {
+        printf("");
+        auto mi = CModelInfo::GetModelInfo(411)->AsVehicleModelInfoPtr();
+        auto type = mi->m_nVehicleType;
+        CVehicle* vehicle = new CAutomobile(561, RANDOM_VEHICLE, true);
+        vehicle->SetPosn(FindPlayerCoors() + CVector(2.f, 0.0f, 2.0f));
+        CWorld::Add(vehicle);
+    }
+    if (pad->IsStandardKeyJustDown('4')) {
+        CVehicle* vehicle = new CBoat(472, PARKED_VEHICLE);
+        vehicle->SetPosn(FindPlayerCoors() + CVector(2.f, 0.0f, 2.0f));
+        CWorld::Add(vehicle);
+    }
 }
 
 void CDebugMenu::ImguiDrawLoop() {


### PR DESCRIPTION
This PR aims add missing virtual funcs to `CVehicle` childs and fixing related problems. May contain reversed func if they pretty simple (will hooked, ex: `GetPlaneNumGuns`) and something like `CPlane::~CPlane`; reversed, but original func will called (gist for futher work).

* Fix signature CPhysical::ProcessEntityCollision

* Reverse CVehicle::GetPlaneNumGuns

* Reverse some CPlain, CHeli and CBike/CBmx funcs

Related #173 