### PR TITLE
Fix task constructors

### DIFF
--- a/source/InjectHooksMain.cpp
+++ b/source/InjectHooksMain.cpp
@@ -503,7 +503,7 @@ void InjectHooksMain() {
         CTaskComplexFollowLeaderInFormation::InjectHooks();
         // CTaskSimpleTriggerLookAt::InjectHooks();
         CTaskSimpleHitHead::InjectHooks();
-        // CTaskUtilityLineUpPedWithCar::InjectHooks();
+        CTaskUtilityLineUpPedWithCar::InjectHooks();
         CTaskSimpleLand::InjectHooks();
         CTaskSimpleJetPack::InjectHooks();
         CTaskSimpleSetStayInSamePlace::InjectHooks();

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarDrive.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarDrive.cpp
@@ -1,9 +1,36 @@
 #include "StdInc.h"
-
 #include "TaskSimpleCarDrive.h"
+#include "TaskUtilityLineUpPedWithCar.h"
 
-CTaskSimpleCarDrive::CTaskSimpleCarDrive(CVehicle* vehicle, CTaskUtilityLineUpPedWithCar* utilityTask, bool updateCurrentVehicle) {
-    plugin::CallMethodAndReturn<CTaskSimpleCarDrive*, 0x63C340, CTaskSimpleCarDrive*, CVehicle*, CTaskUtilityLineUpPedWithCar*, bool>(this, vehicle, utilityTask, updateCurrentVehicle);
+void CTaskSimpleCarDrive::InjectHooks() {
+    RH_ScopedClass(CTaskSimpleCarDrive);
+    RH_ScopedCategory("Tasks/TaskTypes");
+
+    RH_ScopedInstall(Constructor, 0x63C340);
+    RH_ScopedInstall(Destructor, 0x63C460);
+
+    //RH_ScopedInstall(TriggerIK, 0x63C500);
+    //RH_ScopedInstall(UpdateBopping, 0x63C900);
+    //RH_ScopedInstall(StartBopping, 0x642760);
+    //RH_ScopedInstall(ProcessHeadBopping, 0x6428C0);
+    //RH_ScopedInstall(ProcessArmBopping, 0x642AE0);
+    //RH_ScopedInstall(ProcessBopping, 0x642E70);
+
+    //RH_ScopedInstall(Clone_Reversed, 0x63DC20);
+    //RH_ScopedInstall(GetTaskType_Reversed, 0x63C450);
+    //RH_ScopedInstall(MakeAbortable_Reversed, 0x63C670);
+    //RH_ScopedInstall(ProcessPed_Reversed, 0x644470);
+    //RH_ScopedInstall(SetPedPosition_Reversed, 0x63C770);
+}
+
+CTaskSimpleCarDrive::CTaskSimpleCarDrive(CVehicle* vehicle, CTaskUtilityLineUpPedWithCar* utilityTask, bool updateCurrentVehicle) :
+    m_pVehicle{vehicle},
+    m_bUpdateCurrentVehicle{updateCurrentVehicle},
+    m_pTaskUtilityLineUpPedWithCar{ utilityTask ? new CTaskUtilityLineUpPedWithCar{CVector{}, 0, utilityTask->m_doorOpenPosType, utilityTask->m_doorIdx} : nullptr}
+{
+    if (m_pVehicle) {
+        m_pVehicle->RegisterReference(reinterpret_cast<CEntity**>(&m_pVehicle));
+    }
 }
 
 bool CTaskSimpleCarDrive::ProcessPed(CPed* ped) {
@@ -16,15 +43,4 @@ CTask* CTaskSimpleCarDrive::Clone() {
 
 bool CTaskSimpleCarDrive::MakeAbortable(CPed* ped, eAbortPriority priority, const CEvent* event) {
     return plugin::CallMethodAndReturn<bool, 0x63DC20, CTaskSimpleCarDrive*, CPed*, eAbortPriority, const CEvent*>(this, ped, priority, event);
-}
-
-void CTaskSimpleCarDrive::InjectHooks() {
-    RH_ScopedClass(CTaskSimpleCarDrive);
-    RH_ScopedCategory("Tasks/TaskTypes");
-    
-}
-
-CTaskSimpleCarDrive* CTaskSimpleCarDrive::Constructor(CVehicle* vehicle, CTaskUtilityLineUpPedWithCar* utilityTask, bool updateCurrentVehicle) {
-    this->CTaskSimpleCarDrive::CTaskSimpleCarDrive(vehicle, utilityTask, updateCurrentVehicle);
-    return this;
 }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarDrive.h
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarDrive.h
@@ -7,42 +7,37 @@ class CTaskUtilityLineUpPedWithCar;
 
 class CTaskSimpleCarDrive : public CTaskSimple {
 public:
-    CVehicle*                     m_pVehicle;
-    CAnimBlendAssociation*        m_pAnimCloseDoorRolling;
-    CTaskUtilityLineUpPedWithCar* m_pTaskUtilityLineUpPedWithCar;
-    int32                         field_14;
-    int32                         field_18;
-    char                          field_1C;
-    char                          field_1D;
-    char                          field_1E[2];
-    int32                         m_nBoppingStartTime;
-    int32                         field_24;
-    int32                         m_nBoppingEndTime;
+    CVehicle*                     m_pVehicle{};
+    CAnimBlendAssociation*        m_pAnimCloseDoorRolling{};
+    CTaskUtilityLineUpPedWithCar* m_pTaskUtilityLineUpPedWithCar{};
+    int32                         field_14{};
+    int32                         field_18{};
+    char                          field_1C{};
+    char                          field_1D{};
+    int32                         m_nBoppingStartTime{};
+    int32                         field_24{};
+    int32                         m_nBoppingEndTime{};
     float                         m_fBoppingProgress; // 0.0 to 1.0
-    int32                         m_nBoppingCompletedTimes;
-    int32                         m_nHeadBoppingStartTime;
-    int32                         m_nHeadBoppingDirection;
-    float                         m_fHeadBoppingOrientation;
-    float                         m_fRandomHeadBoppingMultiplier;
-    float                         m_fHeadBoppingFactor;
-    int32                         m_nArmBoppingStartTime;
-    int32                         m_nTimePassedSinceCarUpSideDown;
-    CTaskTimer                    m_copCarStolenTimer;
-    union {
-        struct {
-            uint8 m_b01 : 1;
-            uint8 m_b02 : 1;
-            uint8 m_bUpdateCurrentVehicle : 1; // updates m_pVehicle pointer to the current occupied vehicle by ped
-            uint8 m_b04 : 1;
-        };
-        uint8 m_nFlags;
-    };
-    char _pad[3];
+    int32                         m_nBoppingCompletedTimes{};
+    int32                         m_nHeadBoppingStartTime{};
+    int32                         m_nHeadBoppingDirection{};
+    float                         m_fHeadBoppingOrientation{};
+    float                         m_fRandomHeadBoppingMultiplier{};
+    float                         m_fHeadBoppingFactor{};
+    int32                         m_nArmBoppingStartTime{-1};
+    int32                         m_nTimePassedSinceCarUpSideDown{};
+    CTaskTimer                    m_copCarStolenTimer{};
+
+    // Inited according to: 0x63C3AE
+    uint8 m_flag0x1 : 1{};
+    uint8 m_flag0x2 : 1{};
+    uint8 m_bUpdateCurrentVehicle : 1; // Updates m_pVehicle pointer to the current occupied vehicle by ped - Set in ctor
+    uint8 m_flag0x8 : 1{true};
+    uint8 m_flag0x10 : 1{};
+    uint8 m_flag0x20 : 1{};
 
 public:
     static constexpr auto Type = TASK_SIMPLE_CAR_DRIVE;
-
-    CTaskSimpleCarDrive() = delete;
 
     CTaskSimpleCarDrive(CVehicle* vehicle, CTaskUtilityLineUpPedWithCar* utilityTask, bool updateCurrentVehicle);
 
@@ -52,11 +47,26 @@ public:
     bool MakeAbortable(class CPed* ped, eAbortPriority priority, const CEvent* event) override;
 
     auto GetVehicle() const { return m_pVehicle; }
-private:
+
+private: // Wrappers for hooks
     friend void InjectHooksMain();
     static void InjectHooks();
 
-    CTaskSimpleCarDrive* Constructor(CVehicle* vehicle, CTaskUtilityLineUpPedWithCar* utilityTask, bool updateCurrentVehicle);
+    CTaskSimpleCarDrive* Constructor(CVehicle* pVehicle, CTaskUtilityLineUpPedWithCar* pUtilityTask, int8_t bUpdateCurrentVehicle) {
+        this->CTaskSimpleCarDrive::CTaskSimpleCarDrive(pVehicle, pUtilityTask, bUpdateCurrentVehicle);
+        return this;
+    }
+
+    CTaskSimpleCarDrive* Destructor() {
+        this->CTaskSimpleCarDrive::~CTaskSimpleCarDrive();
+        return this;
+    }
+
+    CTask* Clone_Reversed() { return CTaskSimpleCarDrive::Clone(); }
+    eTaskType GetTaskType_Reversed() { return CTaskSimpleCarDrive::GetTaskType(); }
+    bool MakeAbortable_Reversed(CPed* ped, eAbortPriority priority, CEvent const* event) { return CTaskSimpleCarDrive::MakeAbortable(ped, priority, event); }
+    bool ProcessPed_Reversed(CPed* ped) { return CTaskSimpleCarDrive::ProcessPed(ped); }
+    bool SetPedPosition_Reversed(CPed* ped) { return CTaskSimpleCarDrive::SetPedPosition(ped); }
 };
 
 VALIDATE_SIZE(CTaskSimpleCarDrive, 0x60);

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleStandStill.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleStandStill.cpp
@@ -7,6 +7,7 @@ void CTaskSimpleStandStill::InjectHooks()
 {
     RH_ScopedClass(CTaskSimpleStandStill);
     RH_ScopedCategory("Tasks/TaskTypes");
+
     RH_ScopedInstall(Constructor, 0x62F310);
     RH_ScopedInstall(Clone_Reversed, 0x635CF0);
     RH_ScopedInstall(MakeAbortable_Reversed, 0x4B8690);

--- a/source/game_sa/Tasks/TaskTypes/TaskUtilityLineUpPedWithCar.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskUtilityLineUpPedWithCar.cpp
@@ -1,3 +1,46 @@
 #include "StdInc.h"
-
 #include "TaskUtilityLineUpPedWithCar.h"
+
+void CTaskUtilityLineUpPedWithCar::InjectHooks() {
+    RH_ScopedClass(CTaskUtilityLineUpPedWithCar);
+    RH_ScopedCategory("Tasks/TaskTypes");
+
+    RH_ScopedInstall(Constructor, 0x64FBB0);
+    RH_ScopedGlobalInstall(Destructor, 0x64FC00);
+
+    // RH_ScopedInstall(GetLocalPositionToOpenCarDoor, 0x64FC10);
+    // RH_ScopedInstall(GetPositionToOpenCarDoor, 0x650A80);
+    // RH_ScopedInstall(ProcessPed, 0x6513A0);
+}
+
+// 0x64FBB0
+CTaskUtilityLineUpPedWithCar::CTaskUtilityLineUpPedWithCar(const CVector& offset, int32 time, int32 doorOpenPosType, int32 doorIdx) :
+    m_offset{offset},
+    m_time{time},
+    m_doorOpenPosType{doorOpenPosType},
+    m_doorIdx{doorIdx}
+{
+}
+
+// The following 2 functions seem to have copy ellision on the returned CVector, that the compiled functions
+// took a vector ptr as their first arg. Now, hopefully our code will compile to the same stuff.
+// If not, it might crash here, in that case a wrapper function should be used.
+
+// 0x64FC10
+CVector CTaskUtilityLineUpPedWithCar::GetLocalPositionToOpenCarDoor(CVehicle* vehicle, float animProgress, CAnimBlendAssociation* animAssoc) {
+    CVector out;
+    plugin::CallMethodAndReturn<CVector, 0x64FC10, CTaskUtilityLineUpPedWithCar*, CVector*, CVehicle*, float, CAnimBlendAssociation*>(this, &out, vehicle, animProgress, animAssoc);
+    return out;
+}
+
+// 0x650A80
+CVector CTaskUtilityLineUpPedWithCar::GetPositionToOpenCarDoor(CVehicle* vehicle, float animProgress, CAnimBlendAssociation* animAssoc) {
+    CVector out;
+    plugin::CallMethodAndReturn<CVector, 0x650A80, CTaskUtilityLineUpPedWithCar*, CVector*, CVehicle*, float, CAnimBlendAssociation*>(this, &out, vehicle, animProgress, animAssoc);
+    return out;
+}
+
+// 0x6513A0
+bool CTaskUtilityLineUpPedWithCar::ProcessPed(CPed* pPed, CVehicle* pVehicle, CAnimBlendAssociation* pAnimAssoc) {
+    return plugin::CallMethodAndReturn<bool, 0x6513A0, CTaskUtilityLineUpPedWithCar*, CPed*, CVehicle*, CAnimBlendAssociation*>(this, pPed, pVehicle, pAnimAssoc);
+}

--- a/source/game_sa/Tasks/TaskTypes/TaskUtilityLineUpPedWithCar.h
+++ b/source/game_sa/Tasks/TaskTypes/TaskUtilityLineUpPedWithCar.h
@@ -6,21 +6,37 @@
 */
 #pragma once
 
-#include "TaskSimple.h"
-#include "Ped.h"
+#include "Base.h"
+#include "Vector.h"
 
 class CTaskUtilityLineUpPedWithCar {
 public:
-    CVector vecOffsets;
-    int32 field_C;
-    int32 m_nTime;
-    int32 field_14;
-    int32 field_18;
+    CVector m_offset{};
+    float m_doorOpenPosZ{-999.99f};
+    int32_t m_time{};
+    int32_t m_doorOpenPosType{};
+    int32_t m_doorIdx{};
 
-    CTaskUtilityLineUpPedWithCar(const CVector& offsets, int32 nTime, int32 arg3, int32 arg4);
-    CVector* GetLocalPositionToOpenCarDoor(int32 unused, CVehicle* vehicle, float arg3, CAnimBlendAssociation* animBlendAssoc);
-    void ProcessPed(CPed* ped, CVehicle* vehicle, CAnimBlendAssociation* animBlendAssoc);
-    RwV3d* GetPositionToOpenCarDoor(int32 unused, CVehicle* vehicle, float arg2, CAnimBlendAssociation* animBlendAssoc);
+public:
+    CTaskUtilityLineUpPedWithCar(const CVector& offset, int32 time, int32 doorOpenPosType, int32 doorIdx);
+    ~CTaskUtilityLineUpPedWithCar() = default;
+
+    CVector GetLocalPositionToOpenCarDoor(CVehicle* vehicle, float animProgress, CAnimBlendAssociation* animAssoc);
+    CVector GetPositionToOpenCarDoor(CVehicle* vehicle, float animProgress, CAnimBlendAssociation* animAssoc);
+    bool ProcessPed(CPed* pPed, CVehicle* pVehicle, CAnimBlendAssociation* pAnimAssoc);
+
+private: // Wrappers for hooks
+    friend void InjectHooksMain();
+    static void InjectHooks();
+
+    CTaskUtilityLineUpPedWithCar* Constructor(CVector* offsets, int32 nTime, int32 doorOpenPosType, int32 doorIdx) {
+        this->CTaskUtilityLineUpPedWithCar::CTaskUtilityLineUpPedWithCar(offsets, nTime, doorOpenPosType, doorIdx);
+        return this;
+    }
+
+    CTaskUtilityLineUpPedWithCar* Destructor() {
+        this->CTaskUtilityLineUpPedWithCar::~CTaskUtilityLineUpPedWithCar();
+        return this;
+    }
 };
-
 VALIDATE_SIZE(CTaskUtilityLineUpPedWithCar, 0x1C);


### PR DESCRIPTION
As the title says, this PR aims to fix all task constructors, that is, fix #220 when it comes to tasks.

Notes (to myself mostly:
- [ ] Add missing CTaskSimpleCarDrive dtor (Addendum [43e2a5f](https://github.com/Updated-Classic/gta-reversed-modern/pull/256/commits/43e2a5f1d0eba88935f86349d6ce732b7c2890e8) )