### PR TITLE
Make copying function addresses from hook tool possible

### DIFF
--- a/source/reversiblehooks/ReversibleHook/Simple.h
+++ b/source/reversiblehooks/ReversibleHook/Simple.h
@@ -20,12 +20,12 @@ struct Simple : Base {
     SHookContent m_HookContent{};
     uint8        m_OriginalFunctionContent[sizeof(m_HookContent)]{};
     uint32       m_iHookedBytes{};
-    uint32       m_iRealHookedAddress{};
+    uint32       m_iRealHookedAddress{}; // Address of GTA function
 
     SHookContent m_LibHookContent{};
     uint8        m_LibOriginalFunctionContent[sizeof(m_LibHookContent)]{};
     uint32       m_iLibHookedBytes{};
-    uint32       m_iLibFunctionAddress{};
+    uint32       m_iLibFunctionAddress{}; // Address of our function
 
     Simple(std::string fnName, uint32 installAddress, void* addressToJumpTo, int iJmpCodeSize = 5);
 

--- a/source/toolsmenu/DebugModules/HooksDebugModule.cpp
+++ b/source/toolsmenu/DebugModules/HooksDebugModule.cpp
@@ -3,6 +3,8 @@
 #include <reversiblehooks/RootHookCategory.h>
 #include "HooksDebugModule.h"
 #include "Utility.h"
+#include "reversiblehooks/ReversibleHook/Base.h"
+#include "reversiblehooks/ReversibleHook/Simple.h"
 
 #include <imgui.h>
 #include <imgui_stdlib.h>
@@ -393,6 +395,23 @@ void RenderCategory(RH::HookCategory& cat) {
                             cat.SetItemEnabled(item, hooked);
                         }
                         PopID(); // State checkbox
+                    }
+
+                    if (IsItemHovered()) {
+                        switch (item->Type()) {
+                        case RH::ReversibleHook::Base::HookType::Simple: {
+                            auto s = static_cast<RH::ReversibleHook::Simple*>(item.get());
+
+                            SetTooltip("GTA: %#x | Our: %#x", s->m_iRealHookedAddress, s->m_iLibFunctionAddress);
+
+                            if (IsItemClicked(ImGuiMouseButton_Middle)) {
+                                SetClipboardText(std::format("{:#x}", s->m_iRealHookedAddress).c_str());
+                            } else if (IsItemClicked(ImGuiMouseButton_Right)) {
+                                SetClipboardText(std::format("{:#x}", s->m_iLibFunctionAddress).c_str());
+                            }
+                            break;
+                        }
+                        }
                     }
 
                     PopID(); // This hook


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12902714/161455583-ab95d857-23cf-47f2-8d13-4dd026ff6d48.png)
Middle and right mouse buttons can be used to copy them individually. 
The pic has the addresses swapped up, and `0x` prefix missing, but those have been corrected since.
