### PR TITLE
HookOptions: Add `reversed`

### DIFF
--- a/source/game_sa/C_PcSave.cpp
+++ b/source/game_sa/C_PcSave.cpp
@@ -15,11 +15,11 @@ void C_PcSave::InjectHooks() {
 
     // See note in CGenericGameStorage::InjectHooks as to why all this is unhooked by default
 
-    RH_ScopedInstall(SetSaveDirectory, 0x619040, {.enabled = false, .locked = true});
-    RH_ScopedInstall(GenerateGameFilename, 0x6190A0, {.enabled = false, .locked = true});
-    RH_ScopedInstall(PopulateSlotInfo, 0x619140, {.enabled = false, .locked = true});
-    RH_ScopedInstall(SaveSlot, 0x619060, {.enabled = false, .locked = true});
-    RH_ScopedInstall(DeleteSlot, 0x6190D0, {.enabled = false, .locked = true});
+    RH_ScopedInstall(SetSaveDirectory, 0x619040, { .reversed = false });
+    RH_ScopedInstall(GenerateGameFilename, 0x6190A0, { .reversed = false });
+    RH_ScopedInstall(PopulateSlotInfo, 0x619140, { .reversed = false });
+    RH_ScopedInstall(SaveSlot, 0x619060, { .reversed = false });
+    RH_ScopedInstall(DeleteSlot, 0x6190D0, { .reversed = false });
 }
 
 // 0x619040

--- a/source/game_sa/GenericGameStorage.cpp
+++ b/source/game_sa/GenericGameStorage.cpp
@@ -25,24 +25,24 @@ void CGenericGameStorage::InjectHooks() {
     // until we reverse everything.
 
     RH_ScopedInstall(ReportError, 0x5D08C0);
-    RH_ScopedInstall(DoGameSpecificStuffBeforeSave, 0x618F50, { .enabled = false, .locked = true });
-    RH_ScopedInstall(DoGameSpecificStuffAfterSucessLoad, 0x618E90, { .enabled = false, .locked = true });
-    RH_ScopedInstall(InitRadioStationPositionList, 0x618E70, { .enabled = false, .locked = true });
-    RH_ScopedGlobalInstall(GetSavedGameDateAndTime, 0x618D00, { .enabled = false, .locked = true });
-    RH_ScopedInstall(GenericLoad, 0x5D17B0, { .enabled = false, .locked = true });
-    RH_ScopedInstall(GenericSave, 0x5D13E0, { .enabled = false, .locked = true });
-    RH_ScopedInstall(CheckSlotDataValid, 0x5D1380, { .enabled = false, .locked = true });
-    RH_ScopedInstall(LoadDataFromWorkBuffer, 0x5D1300, { .enabled = false, .locked = true });
-    RH_ScopedInstall(SaveDataToWorkBuffer, 0x5D1270, { .enabled = false, .locked = true });
-    RH_ScopedInstall(LoadWorkBuffer, 0x5D10B0, { .enabled = false, .locked = true });
-    RH_ScopedInstall(SaveWorkBuffer, 0x5D0F80, { .enabled = false, .locked = true });
-    RH_ScopedInstall(GetCurrentVersionNumber, 0x5D0F50, { .enabled = false, .locked = true });
-    RH_ScopedInstall(MakeValidSaveName, 0x5D0E90, { .enabled = false, .locked = true });
-    RH_ScopedInstall(CloseFile, 0x5D0E30, { .enabled = false, .locked = true });
-    RH_ScopedInstall(OpenFileForWriting, 0x5D0DD0, { .enabled = false, .locked = true });
-    RH_ScopedInstall(OpenFileForReading, 0x5D0D20, { .enabled = false, .locked = true });
-    RH_ScopedInstall(CheckDataNotCorrupt, 0x5D1170, { .enabled = false, .locked = true });
-    RH_ScopedInstall(RestoreForStartLoad, 0x619000, { .enabled = false, .locked = true });
+    RH_ScopedInstall(DoGameSpecificStuffBeforeSave, 0x618F50, { .reversed = false });
+    RH_ScopedInstall(DoGameSpecificStuffAfterSucessLoad, 0x618E90, { .reversed = false });
+    RH_ScopedInstall(InitRadioStationPositionList, 0x618E70, { .reversed = false });
+    RH_ScopedGlobalInstall(GetSavedGameDateAndTime, 0x618D00, { .reversed = false });
+    RH_ScopedInstall(GenericLoad, 0x5D17B0, { .reversed = false });
+    RH_ScopedInstall(GenericSave, 0x5D13E0, { .reversed = false });
+    RH_ScopedInstall(CheckSlotDataValid, 0x5D1380, { .reversed = false });
+    RH_ScopedInstall(LoadDataFromWorkBuffer, 0x5D1300, { .reversed = false });
+    RH_ScopedInstall(SaveDataToWorkBuffer, 0x5D1270, { .reversed = false });
+    RH_ScopedInstall(LoadWorkBuffer, 0x5D10B0, { .reversed = false });
+    RH_ScopedInstall(SaveWorkBuffer, 0x5D0F80, { .reversed = false });
+    RH_ScopedInstall(GetCurrentVersionNumber, 0x5D0F50, { .reversed = false });
+    RH_ScopedInstall(MakeValidSaveName, 0x5D0E90, { .reversed = false });
+    RH_ScopedInstall(CloseFile, 0x5D0E30, { .reversed = false });
+    RH_ScopedInstall(OpenFileForWriting, 0x5D0DD0, { .reversed = false });
+    RH_ScopedInstall(OpenFileForReading, 0x5D0D20, { .reversed = false });
+    RH_ScopedInstall(CheckDataNotCorrupt, 0x5D1170, { .reversed = false });
+    RH_ScopedInstall(RestoreForStartLoad, 0x619000, { .reversed = false });
 }
 
 // 0x5D08C0

--- a/source/game_sa/Tasks/TaskTypes/TaskComplexTurnToFaceEntityOrCoord.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskComplexTurnToFaceEntityOrCoord.cpp
@@ -11,7 +11,7 @@ void CTaskComplexTurnToFaceEntityOrCoord::InjectHooks() {
     RH_ScopedOverloadedInstall(Constructor, "Entity", 0x66B910, CTaskComplexTurnToFaceEntityOrCoord*(CTaskComplexTurnToFaceEntityOrCoord::*)(CVector const&, float, float));
     RH_ScopedInstall(Destructor, 0x66B960);
     RH_ScopedInstall(ComputeTargetHeading, 0x66B9D0);
-    RH_ScopedVirtualInstall2(ControlSubTask, 0x670920, {.enabled = false, .locked = true});
+    RH_ScopedVirtualInstall2(ControlSubTask, 0x670920, { .reversed = false });
 }
 
 // 0x66B890

--- a/source/reversiblehooks/ReversibleHooks.h
+++ b/source/reversiblehooks/ReversibleHooks.h
@@ -80,10 +80,11 @@ namespace ReversibleHooks {
     };
 
     struct HookInstallOptions {
-        bool enabled{true};
-        bool locked{false};
-        int jmpCodeSize{5};
-        int stackArguments{-1};
+        bool reversed{ true };          // Has this function been reversed?
+        bool enabled{ reversed };       // Is this hook enabled (eg.: redirects GTA calls to ours or vice versa if disabled) by default?
+        bool locked{ !reversed };       // If this hook shouldn't be switchable from the GUI
+        int jmpCodeSize{ 5 };
+        int stackArguments{ -1 };
     };
 
     RootHookCategory& GetRootCategory();


### PR DESCRIPTION
Adds `reversed` option to `HookOptions`, should be used for functions that aren't yet reversed, same as the old `{ .enabled = false, .locked = true }`.

TODO [Separate PR]: Uncomment all commented out hooks and add use `{ .reversed = false }` - Do this in multiple batches, so in case it starts crashing bisect can be used.