### PR TITLE
Fix invalid position transformation in CTaskSimpleRunNamedAnim

### DIFF
--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarWaitToSlowDown.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarWaitToSlowDown.cpp
@@ -12,7 +12,7 @@ void CTaskSimpleCarWaitToSlowDown::InjectHooks() {
     RH_ScopedVMTInstall(GetTaskType, 0x6469F0);
     RH_ScopedVMTInstall(MakeAbortable, 0x646A60);
     RH_ScopedVMTInstall(ProcessPed, 0x646AD0);
-    RH_ScopedVMTInstall(SetPedPosition, 0x646AB0);
+    // crash RH_ScopedVMTInstall(SetPedPosition, 0x646AB0);
 }
 
 // 0x646990

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleRunNamedAnim.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleRunNamedAnim.cpp
@@ -61,6 +61,6 @@ void CTaskSimpleRunNamedAnim::OffsetPedPosition(CPed* ped) {
     ped->UpdateRpHAnim();
     ped->m_bDontUpdateHierarchy = true;
     auto& pos = ped->GetPosition();
-    pos += *ped->m_matrix * m_vecOffsetAtEnd;
+    pos += Multiply3x3(*ped->m_matrix, m_vecOffsetAtEnd);
     m_bOffsetAvailable = false;
 }


### PR DESCRIPTION
fixes #353, couldn't get it to crash on task allocation as in issue report, but player was teleported way out of map bounds, which most likely caused tasks to go crazy